### PR TITLE
Closes #13, Closes #14: Add Command Center button and tab routes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,8 +7,12 @@ import { AuthGuard } from './guards/auth.guard';
 
 const routes: Routes = [
   { path: '', component: LandingComponent },
-  { path: 'command', component: CommandCenterComponent, canActivate: [AuthGuard] },
+  // Redirect bare /command to the default tab
+  { path: 'command', redirectTo: 'command/board', pathMatch: 'full' },
+  // Login must come before the :tab wildcard
   { path: 'command/login', component: AuthGateComponent },
+  // Child tab routes — kanban→board, files, activity, infra, office
+  { path: 'command/:tab', component: CommandCenterComponent, canActivate: [AuthGuard] },
   { path: '**', redirectTo: '' },
 ];
 

--- a/src/app/components/command-center/command-center.component.ts
+++ b/src/app/components/command-center/command-center.component.ts
@@ -1,8 +1,27 @@
-import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 
 export type TabId = 'kanban' | 'files' | 'activity' | 'office' | 'infra';
+
+/** Maps URL path segment → internal tab ID */
+const ROUTE_TO_TAB: Record<string, TabId> = {
+  board: 'kanban',
+  files: 'files',
+  activity: 'activity',
+  infra: 'infra',
+  office: 'office',
+};
+
+/** Maps internal tab ID → URL path segment */
+const TAB_TO_ROUTE: Record<TabId, string> = {
+  kanban: 'board',
+  files: 'files',
+  activity: 'activity',
+  infra: 'infra',
+  office: 'office',
+};
 
 interface Tab {
   id: TabId;
@@ -15,7 +34,7 @@ interface Tab {
   templateUrl: './command-center.component.html',
   styleUrls: ['./command-center.component.scss'],
 })
-export class CommandCenterComponent {
+export class CommandCenterComponent implements OnInit, OnDestroy {
   activeTab: TabId = 'kanban';
 
   tabs: Tab[] = [
@@ -26,10 +45,31 @@ export class CommandCenterComponent {
     { id: 'office', label: 'Office', icon: '🏢' },
   ];
 
-  constructor(private auth: AuthService, private router: Router) {}
+  private routeSub?: Subscription;
 
+  constructor(
+    private auth: AuthService,
+    private router: Router,
+    private route: ActivatedRoute,
+  ) {}
+
+  ngOnInit(): void {
+    // Sync activeTab with the :tab route param on init and whenever it changes
+    this.routeSub = this.route.params.subscribe(params => {
+      const tabId = ROUTE_TO_TAB[params['tab']];
+      if (tabId) {
+        this.activeTab = tabId;
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSub?.unsubscribe();
+  }
+
+  /** Called when user clicks a tab — updates the URL to reflect the new tab */
   setTab(tab: TabId): void {
-    this.activeTab = tab;
+    this.router.navigate(['/command', TAB_TO_ROUTE[tab]]);
   }
 
   logout(): void {

--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -57,6 +57,13 @@
         </svg>
         GitHub
       </a>
+      <a routerLink="/command" class="footer-command-center" title="Command Center">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="terminal-icon">
+          <path d="M20 3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H4V5h16v14zM6.41 15.59L10.83 11 6.41 6.41 7.83 5l6 6-6 6z"
+                fill="currentColor"/>
+        </svg>
+        Command Center
+      </a>
     </div>
   </footer>
 </div>

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -203,6 +203,34 @@
   }
 }
 
+.footer-command-center {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: $text-secondary;
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: color $transition-base, border-color $transition-base;
+  padding: $spacing-xs $spacing-md;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: $radius-xl;
+
+  &:hover {
+    color: $brand-cyan;
+    border-color: rgba($brand-cyan, 0.4);
+  }
+
+  .terminal-icon {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+  }
+
+  &:hover .terminal-icon {
+    opacity: 1;
+  }
+}
+
 // Animations
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(-10px); }


### PR DESCRIPTION
## Summary

### Issue #13 — Command Center button on landing page
- Added a subtle **Command Center** link in the landing page footer (next to the GitHub link)
- Uses `routerLink="/command"` (routed via Angular router, no extra module imports needed — `AppRoutingModule` already exports `RouterModule`)
- Styled to match dark theme with terminal icon, same pill-border style as the GitHub button
- Glows cyan on hover

### Issue #14 — URL route endpoints for Command Center tabs
- `/command` now redirects to `/command/board` (default tab)
- New routes: `/command/board`, `/command/files`, `/command/activity`, `/command/infra`, `/command/office`
- `command/login` kept as a static path (listed before the `:tab` wildcard to avoid conflict)
- `CommandCenterComponent` uses `ActivatedRoute` to read the `:tab` param on init and on navigation
- Clicking a tab calls `router.navigate(['/command', routeSegment])` to update the URL

### Tab ID → Route mapping
| Tab ID | URL segment |
|--------|-------------|
| kanban | board |
| files | files |
| activity | activity |
| infra | infra |
| office | office |

✅ Production build passes.