### PR TITLE
feat: Horizontal scrolling kanban board

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.scss
+++ b/src/app/components/command-center/kanban/kanban.component.scss
@@ -57,12 +57,33 @@
 }
 
 .kanban-board {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: flex;
   gap: $spacing-md;
   flex: 1;
   overflow-x: auto;
+  overflow-y: hidden;
   min-height: 0;
+  padding-bottom: $spacing-sm;
+
+  // Smooth horizontal scroll
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+
+  // Subtle scrollbar
+  &::-webkit-scrollbar {
+    height: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: 3px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    &:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
+  }
 }
 
 .kanban-column {
@@ -71,7 +92,9 @@
   border: 1px solid rgba(255, 255, 255, 0.04);
   display: flex;
   flex-direction: column;
-  min-width: 250px;
+  min-width: 280px;
+  max-width: 320px;
+  flex-shrink: 0;
 }
 
 .column-header {
@@ -316,10 +339,6 @@
 }
 
 @media (max-width: $breakpoint-lg) {
-  .kanban-board {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
   .kanban-header {
     flex-wrap: wrap;
   }
@@ -328,16 +347,15 @@
     margin-left: 0;
     width: 100%;
   }
+
+  .kanban-column {
+    min-width: 240px;
+  }
 }
 
 @media (max-width: $breakpoint-md) {
-  .kanban-board {
-    grid-template-columns: 1fr;
-  }
-
   .kanban-column {
-    min-width: unset;
-    max-height: 400px;
+    min-width: 220px;
   }
 
   .modal-card {


### PR DESCRIPTION
Switches the Kanban board from a stacked grid layout to horizontal scrolling columns.

## Changes
- Columns now scroll left/right instead of wrapping/stacking vertically
- Each column is fixed-width (280-320px) with vertical scroll for cards
- Styled scrollbar for the horizontal board area
- Mobile still scrolls horizontally (no more cramped single-column stacking)