### PR TITLE
feat: Drag-and-drop card movement on Kanban board

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.html
+++ b/src/app/components/command-center/kanban/kanban.component.html
@@ -18,6 +18,10 @@
     <div
       *ngFor="let col of columns"
       class="kanban-column"
+      (dragover)="onDragOver($event)"
+      (dragenter)="onDragEnter($event, col.id)"
+      (dragleave)="onDragLeave($event)"
+      (drop)="onDrop($event, col.id)"
     >
       <div class="column-header" [style.border-bottom-color]="col.color">
         <span class="column-icon">{{ col.icon }}</span>
@@ -29,6 +33,10 @@
         <div
           *ngFor="let card of getColumnCards(col.id)"
           class="kanban-card"
+          draggable="true"
+          [class.dragging]="dragCardId === card.id"
+          (dragstart)="onDragStart($event, card)"
+          (dragend)="onDragEnd()"
         >
           <div class="card-header">
             <span class="card-title">{{ card.title }}</span>

--- a/src/app/components/command-center/kanban/kanban.component.scss
+++ b/src/app/components/command-center/kanban/kanban.component.scss
@@ -148,6 +148,20 @@
     cursor: grabbing;
     opacity: 0.8;
   }
+
+  &.dragging {
+    opacity: 0.3;
+    border: 1px dashed rgba($brand-cyan, 0.4);
+  }
+}
+
+.kanban-column.drag-over {
+  background: rgba($brand-cyan, 0.04);
+  border-color: rgba($brand-cyan, 0.2);
+
+  .column-header {
+    background: rgba($brand-cyan, 0.06);
+  }
 }
 
 .card-header {

--- a/src/app/components/command-center/kanban/kanban.component.ts
+++ b/src/app/components/command-center/kanban/kanban.component.ts
@@ -65,6 +65,57 @@ export class KanbanComponent implements OnInit, OnDestroy {
       .filter(c => !this.repoFilter || c.repo === this.repoFilter);
   }
 
+  dragCardId: string | null = null;
+
+  onDragStart(event: DragEvent, card: BoardCard): void {
+    this.dragCardId = card.id;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', card.id);
+    }
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  onDragEnter(event: DragEvent, columnId: string): void {
+    event.preventDefault();
+    const el = (event.currentTarget as HTMLElement);
+    el.classList.add('drag-over');
+  }
+
+  onDragLeave(event: DragEvent): void {
+    const el = (event.currentTarget as HTMLElement);
+    el.classList.remove('drag-over');
+  }
+
+  async onDrop(event: DragEvent, columnId: string): Promise<void> {
+    event.preventDefault();
+    const el = (event.currentTarget as HTMLElement);
+    el.classList.remove('drag-over');
+
+    const cardId = event.dataTransfer?.getData('text/plain') || this.dragCardId;
+    if (!cardId) return;
+
+    // Don't do anything if dropped in same column
+    const card = this.cards.find(c => c.id === cardId);
+    if (card && card.column === columnId) return;
+
+    const success = await this.boardService.moveCard(cardId, columnId);
+    if (!success) {
+      console.error('Failed to move card');
+    }
+    this.dragCardId = null;
+  }
+
+  onDragEnd(): void {
+    this.dragCardId = null;
+  }
+
   get liveStatus(): string {
     if (!this.lastUpdated) return 'Connecting...';
     const ago = Math.round((Date.now() - new Date(this.lastUpdated).getTime()) / 1000);

--- a/src/app/services/board.service.ts
+++ b/src/app/services/board.service.ts
@@ -60,6 +60,29 @@ export class BoardService implements OnDestroy {
     this.stopPolling();
   }
 
+  async moveCard(cardId: string, targetColumn: string): Promise<boolean> {
+    try {
+      const res = await fetch(environment.apiBaseUrl + '/status/board/move', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Hash': this.auth.getPassphraseHash(),
+        },
+        body: JSON.stringify({ cardId, targetColumn }),
+      });
+      if (!res.ok) return false;
+      // Optimistically update local state
+      const current = this.board$.value;
+      const updatedCards = current.cards.map(c =>
+        c.id === cardId ? { ...c, column: targetColumn } : c
+      );
+      this.board$.next({ ...current, cards: updatedCards, updatedAt: new Date().toISOString() });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async fetch(): Promise<void> {
     try {
       const res = await fetch(this.url, {


### PR DESCRIPTION
Adds drag-and-drop to move cards between columns.

## How it works
- Drag any card and drop it on a target column
- Card fades while dragging, target column highlights on hover
- Persists to API via `PUT /status/board/move` (infra already deployed)
- Optimistic local update for instant feedback

## Backend
Companion infra change already deployed — adds `PUT /status/board/move` endpoint that updates `board-status.json` in S3.

No new dependencies — uses native HTML5 drag-and-drop.