### PR TITLE
feat: Add Idea inbox on Kanban board

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.html
+++ b/src/app/components/command-center/kanban/kanban.component.html
@@ -3,6 +3,10 @@
     <h2>📋 XomBoard</h2>
     <span class="live-status" [class.live]="isLive">{{ liveStatus }}</span>
     <span class="card-count">{{ filteredCount }} active · {{ archivedCards.length }} archived</span>
+    <button class="add-idea-btn" (click)="showAddIdea = true">
+      💡 Add Idea
+      <span *ngIf="pendingIdeas.length > 0" class="pending-badge">{{ pendingIdeas.length }}</span>
+    </button>
     <div class="repo-filters">
       <button class="repo-btn" [class.active]="!repoFilter" (click)="repoFilter = ''">All</button>
       <button
@@ -78,6 +82,47 @@
         <div class="card-footer">
           <span *ngIf="card.repo" class="card-repo">{{ card.repo }}</span>
           <a *ngIf="card.issueUrl" [href]="card.issueUrl" target="_blank" class="card-link">Issue ↗</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Idea Modal -->
+  <div class="modal-overlay" *ngIf="showAddIdea" (click)="showAddIdea = false">
+    <div class="modal-card idea-modal" (click)="$event.stopPropagation()">
+      <h3>💡 Drop an Idea</h3>
+      <p class="idea-hint">Quick thought — Scribe will flesh it out into proper tickets.</p>
+      <form (submit)="$event.preventDefault(); submitIdea()">
+        <input
+          type="text"
+          [(ngModel)]="ideaTitle"
+          placeholder="What needs to happen?"
+          autofocus
+        />
+        <textarea
+          [(ngModel)]="ideaDescription"
+          placeholder="Any extra context? (optional)"
+          rows="3"
+        ></textarea>
+        <input
+          type="text"
+          [(ngModel)]="ideaRepo"
+          placeholder="Repo hint: e.g. xomfit-ios, xomify-frontend (optional)"
+        />
+        <div class="modal-actions">
+          <button type="button" class="btn-cancel" (click)="showAddIdea = false">Cancel</button>
+          <button type="submit" class="btn-add" [disabled]="!ideaTitle.trim() || submittingIdea">
+            {{ submittingIdea ? 'Sending...' : 'Submit Idea' }}
+          </button>
+        </div>
+      </form>
+
+      <!-- Pending ideas -->
+      <div class="pending-list" *ngIf="pendingIdeas.length > 0">
+        <h4>⏳ Waiting for Scribe ({{ pendingIdeas.length }})</h4>
+        <div *ngFor="let idea of pendingIdeas" class="pending-item">
+          <span class="pending-title">{{ idea.title }}</span>
+          <span *ngIf="idea.repoHint" class="pending-repo">{{ idea.repoHint }}</span>
         </div>
       </div>
     </div>

--- a/src/app/components/command-center/kanban/kanban.component.scss
+++ b/src/app/components/command-center/kanban/kanban.component.scss
@@ -352,6 +352,88 @@
   }
 }
 
+// Add Idea button
+.add-idea-btn {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 4px 14px;
+  background: rgba($brand-cyan, 0.08);
+  border: 1px solid rgba($brand-cyan, 0.2);
+  border-radius: $radius-xl;
+  color: $brand-cyan;
+  font-size: 0.8rem;
+  font-family: $font-stack;
+  cursor: pointer;
+  transition: all $transition-base;
+  white-space: nowrap;
+
+  &:hover {
+    background: rgba($brand-cyan, 0.15);
+    border-color: rgba($brand-cyan, 0.4);
+  }
+
+  .pending-badge {
+    background: $brand-cyan;
+    color: #000;
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 10px;
+    min-width: 16px;
+    text-align: center;
+  }
+}
+
+// Idea modal extras
+.idea-modal {
+  max-width: 480px;
+
+  .idea-hint {
+    font-size: 0.8rem;
+    color: $text-muted;
+    margin-bottom: $spacing-md;
+    line-height: 1.4;
+  }
+}
+
+.pending-list {
+  margin-top: $spacing-lg;
+  padding-top: $spacing-md;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+
+  h4 {
+    font-size: 0.8rem;
+    color: $text-muted;
+    margin-bottom: $spacing-sm;
+  }
+}
+
+.pending-item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-xs $spacing-sm;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: $radius-sm;
+  margin-bottom: 4px;
+
+  .pending-title {
+    font-size: 0.8rem;
+    color: $text-secondary;
+    flex: 1;
+  }
+
+  .pending-repo {
+    font-size: 0.7rem;
+    color: $text-muted;
+    background: rgba(255, 255, 255, 0.05);
+    padding: 1px 8px;
+    border-radius: $radius-xl;
+    font-family: 'SF Mono', monospace;
+  }
+}
+
 // Archive section
 .archive-section {
   flex-shrink: 0;

--- a/src/app/components/command-center/kanban/kanban.component.ts
+++ b/src/app/components/command-center/kanban/kanban.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BoardService, BoardCard, BoardColumn } from '../../../services/board.service';
+import { InboxService, InboxItem } from '../../../services/inbox.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -28,9 +29,21 @@ export class KanbanComponent implements OnInit, OnDestroy {
   repoFilter = '';
   repos: string[] = [];
 
-  private boardSub?: Subscription;
+  // Inbox
+  showAddIdea = false;
+  ideaTitle = '';
+  ideaDescription = '';
+  ideaRepo = '';
+  submittingIdea = false;
+  pendingIdeas: InboxItem[] = [];
 
-  constructor(private boardService: BoardService) {}
+  private boardSub?: Subscription;
+  private inboxSub?: Subscription;
+
+  constructor(
+    private boardService: BoardService,
+    private inboxService: InboxService,
+  ) {}
 
   ngOnInit(): void {
     this.boardService.startPolling(30_000);
@@ -43,11 +56,17 @@ export class KanbanComponent implements OnInit, OnDestroy {
       }
       this.repos = [...new Set(this.cards.map(c => c.repo).filter(Boolean) as string[])].sort();
     });
+
+    this.inboxService.fetch();
+    this.inboxSub = this.inboxService.inbox$.subscribe(items => {
+      this.pendingIdeas = items.filter(i => i.status === 'pending');
+    });
   }
 
   ngOnDestroy(): void {
     this.boardService.stopPolling();
     this.boardSub?.unsubscribe();
+    this.inboxSub?.unsubscribe();
   }
 
   getColumnCards(columnId: string): BoardCard[] {
@@ -110,6 +129,23 @@ export class KanbanComponent implements OnInit, OnDestroy {
       console.error('Failed to move card');
     }
     this.dragCardId = null;
+  }
+
+  async submitIdea(): Promise<void> {
+    if (!this.ideaTitle.trim() || this.submittingIdea) return;
+    this.submittingIdea = true;
+    const success = await this.inboxService.addIdea(
+      this.ideaTitle.trim(),
+      this.ideaDescription.trim(),
+      this.ideaRepo.trim(),
+    );
+    this.submittingIdea = false;
+    if (success) {
+      this.ideaTitle = '';
+      this.ideaDescription = '';
+      this.ideaRepo = '';
+      this.showAddIdea = false;
+    }
   }
 
   onDragEnd(): void {

--- a/src/app/services/inbox.service.ts
+++ b/src/app/services/inbox.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environment';
+
+export interface InboxItem {
+  id: string;
+  title: string;
+  description: string;
+  repoHint: string;
+  status: 'pending' | 'processing' | 'processed';
+  createdAt: string;
+  processedAt: string | null;
+  issuesCreated: string[];
+}
+
+export interface InboxResponse {
+  items: InboxItem[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class InboxService {
+  private readonly baseUrl = environment.apiBaseUrl + '/status/board/inbox';
+
+  readonly inbox$ = new BehaviorSubject<InboxItem[]>([]);
+
+  constructor(private auth: AuthService) {}
+
+  async fetch(): Promise<void> {
+    try {
+      const res = await fetch(this.baseUrl, {
+        headers: { 'X-Auth-Hash': this.auth.getPassphraseHash() },
+      });
+      if (!res.ok) return;
+      const data: InboxResponse = await res.json();
+      this.inbox$.next(data.items || []);
+    } catch {
+      // silent
+    }
+  }
+
+  async addIdea(title: string, description: string, repoHint: string): Promise<boolean> {
+    try {
+      const res = await fetch(this.baseUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Auth-Hash': this.auth.getPassphraseHash(),
+        },
+        body: JSON.stringify({ title, description, repoHint }),
+      });
+      if (!res.ok) return false;
+      await this.fetch();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
💡 Quick idea submission → Scribe agent processes into proper tickets.

## How it works
1. Click **💡 Add Idea** in the board header
2. Enter a title, optional description, optional repo hint
3. Idea goes to `board-inbox.json` (staging)
4. Badge shows count of pending ideas
5. Scribe agent picks up pending items and creates detailed GitHub issues

## API (companion infra PR already deployed)
- `GET /status/board/inbox` — list inbox items
- `POST /status/board/inbox` — add new idea
- `PUT /status/board/inbox` — update item (Scribe marks as processed)