### PR TITLE
feat: Add manual refresh button to XomBoard

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.html
+++ b/src/app/components/command-center/kanban/kanban.component.html
@@ -2,6 +2,7 @@
   <div class="kanban-header">
     <h2>📋 XomBoard</h2>
     <span class="live-status" [class.live]="isLive">{{ liveStatus }}</span>
+    <button class="refresh-btn" (click)="refreshBoard()" title="Refresh board now">🔄 Refresh</button>
     <span class="card-count">{{ filteredCount }} / {{ cards.length }} items</span>
     <div class="repo-filters">
       <button class="repo-btn" [class.active]="!repoFilter" (click)="repoFilter = ''">All</button>

--- a/src/app/components/command-center/kanban/kanban.component.scss
+++ b/src/app/components/command-center/kanban/kanban.component.scss
@@ -17,6 +17,35 @@
     color: $text-primary;
   }
 
+  .live-status {
+    font-size: 0.75rem;
+    color: $text-muted;
+    padding: 2px 8px;
+    border-radius: $radius-md;
+    
+    &.live {
+      color: #4ade80;
+      background: rgba(74, 222, 128, 0.1);
+    }
+  }
+
+  .refresh-btn {
+    padding: 4px 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: $radius-md;
+    color: $text-secondary;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all $transition-base;
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.2);
+      color: $text-primary;
+    }
+  }
+
   .card-count {
     font-size: 0.8rem;
     color: $text-muted;

--- a/src/app/components/command-center/kanban/kanban.component.ts
+++ b/src/app/components/command-center/kanban/kanban.component.ts
@@ -66,4 +66,8 @@ export class KanbanComponent implements OnInit, OnDestroy {
     if (ago < 60) return `Live — updated ${ago}s ago`;
     return `Updated ${Math.round(ago / 60)}m ago`;
   }
+
+  refreshBoard(): void {
+    this.boardService.fetch();
+  }
 }

--- a/src/app/services/board.service.ts
+++ b/src/app/services/board.service.ts
@@ -59,7 +59,7 @@ export class BoardService implements OnDestroy {
     this.stopPolling();
   }
 
-  private async fetch(): Promise<void> {
+  async fetch(): Promise<void> {
     try {
       const res = await fetch(this.url, {
         headers: {


### PR DESCRIPTION
## Changes
- Added 🔄 Refresh button in kanban header
- Users can click to manually refresh board immediately (no waiting 30s)
- Shows live status with last update timestamp
- Refresh button styling matches Command Center theme

## How to use
Click the 'Refresh' button next to the live status indicator to fetch the latest board state.