### PR TITLE
Add refresh button to XomBoard

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.html
+++ b/src/app/components/command-center/kanban/kanban.component.html
@@ -2,6 +2,7 @@
   <div class="kanban-header">
     <h2>📋 XomBoard</h2>
     <span class="live-status" [class.live]="isLive">{{ liveStatus }}</span>
+    <button class="refresh-btn" (click)="refreshBoard()">🔄 Refresh</button>
     <span class="card-count">{{ filteredCount }} active · {{ archivedCards.length }} archived</span>
     <button class="add-idea-btn" (click)="showAddIdea = true">
       💡 Add Idea


### PR DESCRIPTION
Adds manual refresh button so you can update the board immediately instead of waiting 30 seconds for auto-poll