### PR TITLE
feat: diagonal caution tape overlay over coming-soon cards

### DIFF
--- a/src/app/components/coming-soon/caution-tape/caution-tape.component.scss
+++ b/src/app/components/coming-soon/caution-tape/caution-tape.component.scss
@@ -28,7 +28,8 @@
     font-family: 'Courier New', monospace;
     font-size: 13px;
     font-weight: 700;
-    color: $caution-black;
+    color: #ffffff;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9), 0 0 6px rgba(0, 0, 0, 0.6);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     padding: 0 0; // spacing is in the text itself

--- a/src/app/components/coming-soon/caution-tape/caution-tape.component.ts
+++ b/src/app/components/coming-soon/caution-tape/caution-tape.component.ts
@@ -11,7 +11,7 @@ export class CautionTapeComponent {
     '🚧 UNDER CONSTRUCTION · 🔧 COMING SOON · ⚡ XOMWARE LABS · 🤖 AGENTS BUILDING · ';
 
   /** Duration of one full scroll cycle in seconds. */
-  @Input() public speed: number = 60;
+  @Input() public speed: number = 120;
 
   /**
    * Repeat the text enough times to guarantee seamless looping.

--- a/src/app/components/coming-soon/coming-soon-section/coming-soon-section.component.html
+++ b/src/app/components/coming-soon/coming-soon-section/coming-soon-section.component.html
@@ -6,15 +6,20 @@
     <p class="section-subtitle">Forge is hard at work. These ship soon.</p>
   </div>
 
-  <!-- Caution tape directly above the app cards -->
-  <app-caution-tape></app-caution-tape>
+  <!-- Cards zone: cards + diagonal caution tape overlay -->
+  <div class="cards-zone">
+    <!-- Card grid -->
+    <div class="coming-soon-grid">
+      <app-coming-soon-card
+        *ngFor="let app of apps"
+        [app]="app"
+      ></app-coming-soon-card>
+    </div>
 
-  <!-- Card grid -->
-  <div class="coming-soon-grid">
-    <app-coming-soon-card
-      *ngFor="let app of apps"
-      [app]="app"
-    ></app-coming-soon-card>
+    <!-- Diagonal caution tape crossing OVER both cards -->
+    <div class="diagonal-tape-wrap" aria-hidden="true">
+      <app-caution-tape [speed]="120"></app-caution-tape>
+    </div>
   </div>
 
   <!-- Footer hint -->

--- a/src/app/components/coming-soon/coming-soon-section/coming-soon-section.component.scss
+++ b/src/app/components/coming-soon/coming-soon-section/coming-soon-section.component.scss
@@ -42,6 +42,14 @@
   margin: 0;
 }
 
+// ─── Cards Zone (relative container for diagonal tape overlay) ───────────────
+
+.cards-zone {
+  position: relative;
+  padding: $spacing-xl $spacing-md;
+  overflow: hidden; // clips tape ends cleanly after rotation
+}
+
 // ─── Cards Grid ──────────────────────────────────────────────────────────────
 
 .coming-soon-grid {
@@ -49,12 +57,26 @@
   justify-content: center;
   flex-wrap: wrap;
   gap: $spacing-xl;
-  padding: 0 $spacing-md;
+  position: relative;
+  z-index: 1; // cards sit below the tape overlay
 }
 
 .card-wrapper {
   display: flex;
   justify-content: center;
+}
+
+// ─── Diagonal Tape Overlay ───────────────────────────────────────────────────
+
+.diagonal-tape-wrap {
+  position: absolute;
+  top: 50%;
+  left: -25%;
+  width: 150%;
+  transform: translateY(-50%) rotate(-14deg);
+  z-index: 10;
+  pointer-events: none; // cards underneath remain interactive
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.6));
 }
 
 // ─── Footer Hint ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### 🚧 Diagonal Tape Over Cards
- Moved caution tape from horizontal banner above cards to **diagonal overlay crossing over both xomfit + Float cards**
- Wrapped card grid in `.cards-zone` (position: relative, overflow: hidden)
- Added `.diagonal-tape-wrap` (position: absolute, top: 50%, rotate(-14deg), z-index: 10)
- Cards remain interactive (`pointer-events: none` on tape overlay)
- Drop shadow added to tape for visual depth

### ⏱ Scroll Speed
- Default animation duration: **60s → 120s** (dramatic slow crawl effect)

### 🎨 White Text
- Text color changed from `$caution-black` to **`#ffffff`** with dark text-shadow for readability over yellow/black stripe background

## Files Changed
- `caution-tape.component.ts` — speed default 60→120
- `caution-tape.component.scss` — white text + text-shadow
- `coming-soon-section.component.html` — cards-zone wrapper + diagonal tape
- `coming-soon-section.component.scss` — .cards-zone + .diagonal-tape-wrap styles