### PR TITLE
fix: Files/docs mobile visibility + view/edit toggle with markdown-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/router": "^18.2.14",
         "gsap": "^3.14.2",
         "lottie-web": "^5.13.0",
+        "markdown-it": "^14.1.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -26,6 +27,7 @@
         "@angular/cli": "~18.2.21",
         "@angular/compiler-cli": "^18.2.14",
         "@types/jasmine": "~4.3.0",
+        "@types/markdown-it": "^14.1.2",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -4895,6 +4897,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -5454,6 +5481,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6520,13 +6553,6 @@
         }
       }
     },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -7063,7 +7089,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -9252,6 +9277,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listr2": {
       "version": "8.2.4",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.4.tgz",
@@ -9742,6 +9776,23 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9751,6 +9802,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -11407,6 +11464,15 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qjobs": {
       "version": "1.2.0",
@@ -13142,6 +13208,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/router": "^18.2.14",
     "gsap": "^3.14.2",
     "lottie-web": "^5.13.0",
+    "markdown-it": "^14.1.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },
@@ -29,6 +30,7 @@
     "@angular/cli": "~18.2.21",
     "@angular/compiler-cli": "^18.2.14",
     "@types/jasmine": "~4.3.0",
+    "@types/markdown-it": "^14.1.2",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/components/command-center/file-editor/file-editor.component.html
+++ b/src/app/components/command-center/file-editor/file-editor.component.html
@@ -5,8 +5,20 @@
     <button class="retry-btn" (click)="loadFiles()">Retry</button>
   </div>
 
+  <!-- Mobile file selector (visible on small screens, outside sidebar) -->
+  <select
+    class="file-dropdown"
+    [value]="selectedFile?.name || ''"
+    (change)="selectFile({ name: $any($event.target).value })"
+  >
+    <option value="" disabled>Select a file…</option>
+    <option *ngFor="let file of files" [value]="file.name">
+      {{ getIcon(file.name) }} {{ file.name }}
+    </option>
+  </select>
+
   <div class="editor-layout">
-    <!-- File sidebar -->
+    <!-- File sidebar (desktop) -->
     <aside class="file-sidebar">
       <div class="sidebar-header">
         <h3>📂 Files</h3>
@@ -15,19 +27,6 @@
         </button>
       </div>
 
-      <!-- Mobile dropdown -->
-      <select
-        class="file-dropdown"
-        [value]="selectedFile?.name || ''"
-        (change)="selectFile({ name: $any($event.target).value })"
-      >
-        <option value="" disabled>Select a file…</option>
-        <option *ngFor="let file of files" [value]="file.name">
-          {{ getIcon(file.name) }} {{ file.name }}
-        </option>
-      </select>
-
-      <!-- Desktop list -->
       <div class="file-list">
         <div *ngIf="loading && files.length === 0" class="loading-indicator">
           Loading…
@@ -50,8 +49,8 @@
     <main class="editor-panel">
       <div *ngIf="!selectedFile && !loading" class="empty-state">
         <span class="empty-icon">📝</span>
-        <p>Select a file to edit</p>
-        <p class="empty-hint">⌘+S to save</p>
+        <p>Select a file to view</p>
+        <p class="empty-hint">Defaults to View mode — click ✏️ Edit to make changes</p>
       </div>
 
       <div *ngIf="selectedFile" class="editor-container">
@@ -64,12 +63,12 @@
           </div>
           <div class="toolbar-right">
             <button
-              class="toolbar-btn"
-              [class.active]="previewMode"
+              class="toolbar-btn view-edit-btn"
+              [class.edit-active]="!previewMode"
               (click)="togglePreview()"
-              title="Toggle preview"
+              [title]="previewMode ? 'Switch to Edit mode' : 'Switch to View mode'"
             >
-              {{ previewMode ? '✏️ Edit' : '👁️ Preview' }}
+              {{ previewMode ? '✏️ Edit' : '👁️ View' }}
             </button>
             <button
               class="toolbar-btn revert-btn"
@@ -101,7 +100,7 @@
           Loading file…
         </div>
 
-        <!-- Editor textarea -->
+        <!-- Editor textarea (Edit mode) -->
         <div *ngIf="!previewMode && !loading" class="editor-wrapper">
           <div class="line-numbers" aria-hidden="true">
             <span *ngFor="let line of editorContent.split('\n'); let i = index">{{ i + 1 }}</span>
@@ -117,9 +116,9 @@
           ></textarea>
         </div>
 
-        <!-- Preview -->
-        <div *ngIf="previewMode && !loading" class="editor-preview">
-          <pre class="preview-content">{{ editorContent }}</pre>
+        <!-- Rendered markdown preview (View mode) -->
+        <div *ngIf="previewMode && !loading" class="editor-preview markdown-body">
+          <div [innerHTML]="renderedMarkdown"></div>
         </div>
       </div>
     </main>

--- a/src/app/components/command-center/file-editor/file-editor.component.scss
+++ b/src/app/components/command-center/file-editor/file-editor.component.scss
@@ -34,6 +34,11 @@
   }
 }
 
+// Mobile file dropdown — hidden by default, shown on mobile
+.file-dropdown {
+  display: none;
+}
+
 // Layout
 .editor-layout {
   flex: 1;
@@ -91,10 +96,6 @@
     opacity: 0.4;
     cursor: not-allowed;
   }
-}
-
-.file-dropdown {
-  display: none;
 }
 
 .file-list {
@@ -196,6 +197,8 @@
   .empty-hint {
     font-size: 0.75rem;
     opacity: 0.6;
+    text-align: center;
+    max-width: 240px;
   }
 }
 
@@ -274,6 +277,23 @@
     background: rgba($brand-cyan, 0.1);
     border-color: rgba($brand-cyan, 0.3);
     color: $brand-cyan;
+  }
+}
+
+// View/Edit toggle — highlights when in edit mode
+.view-edit-btn {
+  border-color: rgba($brand-cyan, 0.2);
+  color: $text-secondary;
+
+  &:hover:not(:disabled) {
+    border-color: rgba($brand-cyan, 0.4);
+    color: $brand-cyan;
+  }
+
+  &.edit-active {
+    background: rgba(255, 165, 0, 0.1);
+    border-color: rgba(255, 165, 0, 0.4);
+    color: #ffa500;
   }
 }
 
@@ -375,21 +395,121 @@
   }
 }
 
-// Preview
+// Preview / View mode
 .editor-preview {
   flex: 1;
   padding: $spacing-lg;
   overflow-y: auto;
 }
 
-.preview-content {
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 0.8rem;
+// Markdown rendered output
+.markdown-body {
   color: $text-secondary;
+  font-size: 0.9rem;
   line-height: 1.7;
-  white-space: pre-wrap;
-  word-break: break-word;
-  margin: 0;
+
+  h1, h2, h3, h4, h5, h6 {
+    color: $text-primary;
+    margin: 1.2em 0 0.5em;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  h1 { font-size: 1.6rem; border-bottom: 1px solid rgba(255,255,255,0.08); padding-bottom: 0.3em; }
+  h2 { font-size: 1.3rem; border-bottom: 1px solid rgba(255,255,255,0.05); padding-bottom: 0.2em; }
+  h3 { font-size: 1.1rem; color: $brand-cyan; }
+  h4 { font-size: 1rem; color: $text-secondary; }
+
+  p {
+    margin: 0.6em 0;
+  }
+
+  a {
+    color: $brand-cyan;
+    text-decoration: none;
+    &:hover { text-decoration: underline; }
+  }
+
+  code {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.82em;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    padding: 0.15em 0.4em;
+    color: $brand-cyan;
+  }
+
+  pre {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: $radius-md;
+    padding: $spacing-md;
+    overflow-x: auto;
+    margin: 0.8em 0;
+
+    code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 0.8rem;
+      color: $text-secondary;
+      line-height: 1.65;
+    }
+  }
+
+  ul, ol {
+    margin: 0.5em 0;
+    padding-left: 1.5em;
+
+    li {
+      margin: 0.2em 0;
+    }
+  }
+
+  blockquote {
+    margin: 0.8em 0;
+    padding: $spacing-sm $spacing-md;
+    border-left: 3px solid $brand-cyan;
+    background: rgba($brand-cyan, 0.05);
+    color: $text-muted;
+    font-style: italic;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    margin: 1.2em 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.8em 0;
+    font-size: 0.85rem;
+
+    th {
+      background: rgba(255, 255, 255, 0.05);
+      color: $text-primary;
+      font-weight: 600;
+      padding: $spacing-xs $spacing-sm;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      text-align: left;
+    }
+
+    td {
+      padding: $spacing-xs $spacing-sm;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      color: $text-secondary;
+    }
+
+    tr:nth-child(even) td {
+      background: rgba(255, 255, 255, 0.02);
+    }
+  }
+
+  strong { color: $text-primary; font-weight: 600; }
+  em { color: $text-secondary; font-style: italic; }
 }
 
 // Responsive
@@ -398,6 +518,7 @@
     display: none;
   }
 
+  // Show mobile dropdown above the editor layout
   .file-dropdown {
     display: block;
     width: 100%;

--- a/src/app/components/command-center/file-editor/file-editor.component.ts
+++ b/src/app/components/command-center/file-editor/file-editor.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { FileService, WorkspaceFile } from '../../../services/file.service';
+import MarkdownIt from 'markdown-it';
 
 interface FileIcon {
   [key: string]: string;
@@ -15,12 +17,15 @@ export class FileEditorComponent implements OnInit {
   selectedFile: WorkspaceFile | null = null;
   editorContent = '';
   originalContent = '';
-  previewMode = false;
+  /** true = View mode (rendered markdown), false = Edit mode (raw text) */
+  previewMode = true;
   loading = false;
   saving = false;
   saveSuccess = false;
   saveError = '';
   loadError = '';
+
+  private md = new MarkdownIt({ html: false, linkify: true, typographer: true });
 
   readonly fileIcons: FileIcon = {
     'SOUL.md': '🧬',
@@ -35,7 +40,10 @@ export class FileEditorComponent implements OnInit {
 
   readonly defaultIcon = '📄';
 
-  constructor(private fileService: FileService) {}
+  constructor(
+    private fileService: FileService,
+    private sanitizer: DomSanitizer,
+  ) {}
 
   ngOnInit(): void {
     this.loadFiles();
@@ -59,7 +67,8 @@ export class FileEditorComponent implements OnInit {
     this.loadError = '';
     this.saveSuccess = false;
     this.saveError = '';
-    this.previewMode = false;
+    // Default to view mode on each new file selection
+    this.previewMode = true;
     try {
       const result = await this.fileService.getFile(file.name);
       this.selectedFile = result;
@@ -82,6 +91,11 @@ export class FileEditorComponent implements OnInit {
 
   get lineCount(): number {
     return this.editorContent ? this.editorContent.split('\n').length : 0;
+  }
+
+  get renderedMarkdown(): SafeHtml {
+    const html = this.md.render(this.editorContent || '');
+    return this.sanitizer.bypassSecurityTrustHtml(html);
   }
 
   togglePreview(): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
## Summary

Fixes three issues with the Files (docs) tab in Command Center:

### 1. 🐛 Mobile Layout Fix
The file selector dropdown was placed **inside** , which is hidden on mobile via `display: none`. The dropdown never rendered on small screens, making the whole docs section unusable on mobile.

**Fix:** Moved the `<select class="file-dropdown">` element **outside** the sidebar, directly inside `.file-editor`. It's hidden on desktop and shown on mobile via media query.

### 2. 👁️ Default View Mode (Rendered Markdown)
Previously defaulted to edit mode (`previewMode = false`). Now defaults to **View mode** (`previewMode = true`) on every file open — better for read-heavy docs.

### 3. ✏️ Edit Mode Toggle + markdown-it Pretty Rendering
- Toggle button now reads `✏️ Edit` (to switch to raw editor) or `👁️ View` (to switch back)
- View mode now renders proper markdown via **markdown-it** instead of a plain `<pre>` block
- Headers, code blocks, tables, blockquotes, lists all styled for the dark theme
- Added `allowSyntheticDefaultImports` to tsconfig for markdown-it ESM compat

## Files Changed
- `file-editor.component.ts` — DomSanitizer + markdown-it, default previewMode=true
- `file-editor.component.html` — dropdown outside sidebar, innerHTML markdown binding
- `file-editor.component.scss` — dropdown mobile rules, full .markdown-body styles
- `tsconfig.json` — allowSyntheticDefaultImports
- `package.json` — markdown-it + @types/markdown-it