### PR TITLE
fix: board refresh button — loading state, spin animation, polling order fix

### DIFF
--- a/src/app/components/command-center/kanban/kanban.component.html
+++ b/src/app/components/command-center/kanban/kanban.component.html
@@ -2,7 +2,10 @@
   <div class="kanban-header">
     <h2>📋 XomBoard</h2>
     <span class="live-status" [class.live]="isLive">{{ liveStatus }}</span>
-    <button class="refresh-btn" (click)="refreshBoard()">🔄 Refresh</button>
+    <button class="refresh-btn" (click)="refreshBoard()" [disabled]="isRefreshing" [class.refreshing]="isRefreshing">
+      <span class="refresh-icon" [class.spin]="isRefreshing">🔄</span>
+      {{ isRefreshing ? 'Refreshing...' : 'Refresh' }}
+    </button>
     <span class="card-count">{{ filteredCount }} active · {{ archivedCards.length }} archived</span>
     <button class="add-idea-btn" (click)="showAddIdea = true">
       💡 Add Idea

--- a/src/app/components/command-center/kanban/kanban.component.scss
+++ b/src/app/components/command-center/kanban/kanban.component.scss
@@ -352,6 +352,49 @@
   }
 }
 
+// Refresh button
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.refresh-btn {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: $radius-xl;
+  color: $text-secondary;
+  font-size: 0.8rem;
+  font-family: $font-stack;
+  cursor: pointer;
+  transition: all $transition-base;
+  white-space: nowrap;
+
+  .refresh-icon {
+    display: inline-block;
+    line-height: 1;
+
+    &.spin {
+      animation: spin 0.8s linear infinite;
+    }
+  }
+
+  &:hover:not(:disabled) {
+    border-color: rgba($brand-cyan, 0.4);
+    color: $brand-cyan;
+    background: rgba($brand-cyan, 0.05);
+  }
+
+  &:disabled,
+  &.refreshing {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
 // Add Idea button
 .add-idea-btn {
   display: flex;

--- a/src/app/components/command-center/kanban/kanban.component.ts
+++ b/src/app/components/command-center/kanban/kanban.component.ts
@@ -24,6 +24,7 @@ export class KanbanComponent implements OnInit, OnDestroy {
   archivedCards: BoardCard[] = [];
   lastUpdated: string | null = null;
   isLive = false;
+  isRefreshing = false;
   showArchive = false;
 
   // Filtering
@@ -40,6 +41,7 @@ export class KanbanComponent implements OnInit, OnDestroy {
 
   private boardSub?: Subscription;
   private inboxSub?: Subscription;
+  private refreshSub?: Subscription;
 
   constructor(
     private boardService: BoardService,
@@ -58,6 +60,10 @@ export class KanbanComponent implements OnInit, OnDestroy {
       this.repos = [...new Set(this.cards.map(c => c.repo).filter(Boolean) as string[])].sort();
     });
 
+    this.refreshSub = this.boardService.isRefreshing$.subscribe(v => {
+      this.isRefreshing = v;
+    });
+
     this.inboxService.fetch();
     this.inboxSub = this.inboxService.inbox$.subscribe(items => {
       this.pendingIdeas = items.filter(i => i.status === 'pending');
@@ -68,6 +74,7 @@ export class KanbanComponent implements OnInit, OnDestroy {
     this.boardService.stopPolling();
     this.boardSub?.unsubscribe();
     this.inboxSub?.unsubscribe();
+    this.refreshSub?.unsubscribe();
   }
 
   getColumnCards(columnId: string): BoardCard[] {
@@ -149,8 +156,8 @@ export class KanbanComponent implements OnInit, OnDestroy {
     }
   }
 
-  refreshBoard(): void {
-    this.boardService.fetch();
+  async refreshBoard(): Promise<void> {
+    await this.boardService.fetch();
   }
 
   onDragEnd(): void {

--- a/src/app/services/board.service.ts
+++ b/src/app/services/board.service.ts
@@ -41,11 +41,13 @@ export class BoardService implements OnDestroy {
     cards: [],
   });
 
+  readonly isRefreshing$ = new BehaviorSubject<boolean>(false);
+
   constructor(private auth: AuthService) {}
 
   startPolling(intervalMs = 30_000): void {
+    this.stopPolling(); // stop any existing timer before starting fresh
     this.fetch(); // immediate first fetch
-    this.stopPolling();
     this.pollTimer = setInterval(() => this.fetch(), intervalMs);
   }
 
@@ -84,6 +86,7 @@ export class BoardService implements OnDestroy {
   }
 
   async fetch(): Promise<void> {
+    this.isRefreshing$.next(true);
     try {
       const res = await fetch(this.url, {
         headers: {
@@ -95,6 +98,8 @@ export class BoardService implements OnDestroy {
       this.board$.next(data);
     } catch {
       // silent fail — board just shows stale data
+    } finally {
+      this.isRefreshing$.next(false);
     }
   }
 }


### PR DESCRIPTION
## Problem
The refresh button on XomBoard had multiple issues:
1. **No CSS styles** — the `.refresh-btn` class was completely absent from `kanban.component.scss`, causing it to render as an ugly unstyled browser default button
2. **No loading feedback** — clicking Refresh gave zero visual indication that a fetch was in progress
3. **`startPolling()` ordering bug** — called `fetch()` before `stopPolling()`, meaning if called multiple times there could be duplicate polling intervals
4. **`refreshBoard()` was fire-and-forget** — returned void without awaiting, so no way to tie UI state to completion

## Fix
- Added `isRefreshing$: BehaviorSubject<boolean>` to `BoardService`; set `true` before fetch, `false` in `finally` block
- Fixed `startPolling()` to call `stopPolling()` first, then `fetch()`, then set timer
- `KanbanComponent` subscribes to `isRefreshing$` and exposes `isRefreshing: boolean`
- `refreshBoard()` is now `async` and properly awaits `boardService.fetch()`
- Refresh button: disabled while fetching, shows `Refreshing...` text and spinning 🔄 icon (CSS `@keyframes spin` animation)
- Added complete `.refresh-btn` styles matching the design system (dark bg, cyan hover, consistent with `.add-idea-btn`)

## Testing
- Build passes cleanly (`ng build --configuration production`)
- Manual refresh click disables button and shows spinner immediately
- Button re-enables after API response completes
- No duplicate polling timers