### PR TITLE
ui-polish: staggered card animations + hero scroll hint

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -13,6 +13,12 @@
         &#64;domgiordano
       </a>
     </p>
+    <!-- Scroll hint -->
+    <div class="scroll-hint">
+      <svg class="scroll-arrow" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" fill="currentColor"/>
+      </svg>
+    </div>
   </header>
 
   <!-- Monster Section -->
@@ -23,9 +29,10 @@
   <!-- App Cards Section -->
   <section class="apps-section">
     <div class="cards-container">
-      <a *ngFor="let app of apps"
+      <a *ngFor="let app of apps; let i = index"
          class="app-card"
          [style.--app-color]="app.color"
+         [style.animation-delay]="(i * 0.12) + 's'"
          [href]="app.url"
          target="_blank"
          rel="noopener"

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -88,6 +88,7 @@
   transition: all $transition-base;
   position: relative;
   overflow: hidden;
+  animation: cardSlideUp 0.5s ease-out both;
 
   &::before {
     content: '';
@@ -231,6 +232,27 @@
   }
 }
 
+// Scroll hint indicator
+.scroll-hint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: $text-muted;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  animation: fadeIn 1s ease-out 0.8s both;
+  margin-top: $spacing-md;
+
+  .scroll-arrow {
+    width: 20px;
+    height: 20px;
+    animation: bounce 1.8s ease-in-out infinite;
+  }
+}
+
 // Animations
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(-10px); }
@@ -240,6 +262,22 @@
 @keyframes float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-8px); }
+}
+
+@keyframes cardSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(5px); }
 }
 
 // Responsive


### PR DESCRIPTION
## UI Polish: Staggered Card Animations + Hero Scroll Hint

### What Changed
- **Staggered card entry**: Each app card now slides up with a 0.12s stagger delay per index position, giving a smooth cascade effect on page load
- **Hero scroll hint**: Animated bouncing chevron in the hero section guides users to scroll down
- **New `cardSlideUp` keyframe**: Cards fade in from `translateY(24px)` to natural position
- **New `bounce` keyframe**: Scroll arrow gently pulses every 1.8s

### Implementation
```html
<!-- ngFor now tracks index for stagger delay -->
<a *ngFor="let app of apps; let i = index"
   [style.animation-delay]="(i * 0.12) + 's'">
```
```scss
.app-card {
  animation: cardSlideUp 0.5s ease-out both; /* animation-delay set inline */
}
```

### Best Practices Checklist
- [x] **Model routing**: This is Haiku-tier work (pure CSS/template, no logic changes)
- [x] **Pre-commit gate FIRED**: TypeScript check → ✅ PASS (2 staged files)
- [x] **Pre-push gate FIRED**: TypeScript ✅ + Production build ✅ → push allowed
- [x] **MCP tools ≤10**: Session has exactly 10 tools (Read, Write, Edit, exec, process, sessions_list, sessions_history, subagents, image, sessions_spawn)
- [x] Pure visual enhancement, zero breaking changes
- [x] Responsive layout unaffected (stagger degrades gracefully to no animation)

### Gate Logs
```
[pre-commit][01:27:09] 🔒 PRE-COMMIT GATE FIRED
[pre-commit][01:27:09] Branch: ui-polish/staggered-card-animations
[pre-commit][01:27:09] Staged files: 2
[pre-commit][01:27:09]   → src/app/components/landing/landing.component.html
[pre-commit][01:27:09]   → src/app/components/landing/landing.component.scss
[pre-commit][01:27:11] ✅ TypeScript: PASS
[pre-commit][01:27:11] ✅ All pre-commit gates PASSED — proceeding with commit

[pre-push][01:27:14] 🚀 PRE-PUSH (PRE-MERGE) GATE FIRED
[pre-push][01:27:14] Remote: origin → https://github.com/Xomware/xomware-frontend.git
[pre-push][01:27:16] ✅ TypeScript: PASS
[pre-push][01:27:22] ✅ Build: PASS
[pre-push][01:27:22] ✅ All pre-push gates PASSED — proceeding with push
```