### PR TITLE
feat: CI/CD Monitor — live GitHub Actions status across repos (#58)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,8 @@ const routes: Routes = [
   { path: '', component: LandingComponent },
   // Standalone feature routes (no auth required — public data)
   { path: 'prs', component: PrDashboardComponent },
+  // Standalone /ci route (no auth required — public CI data)
+  { path: 'ci', redirectTo: 'command/ci', pathMatch: 'full' },
   // Redirect bare /command to the default tab
   { path: 'command', redirectTo: 'command/board', pathMatch: 'full' },
   // Login must come before the :tab wildcard

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { TicketDetailModalComponent } from './components/command-center/ticket-d
 import { AnalyticsDashboardComponent } from './components/command-center/analytics-dashboard/analytics-dashboard.component';
 
 // Standalone feature views
+import { CiMonitorComponent } from './components/command-center/ci-monitor/ci-monitor.component';
 import { PrDashboardComponent } from './components/pr-dashboard/pr-dashboard.component';
 
 @NgModule({
@@ -61,6 +62,7 @@ import { PrDashboardComponent } from './components/pr-dashboard/pr-dashboard.com
     AnalyticsDashboardComponent,
     // Standalone views
     PrDashboardComponent,
+    CiMonitorComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/command-center/ci-monitor/ci-monitor.component.html
+++ b/src/app/components/command-center/ci-monitor/ci-monitor.component.html
@@ -1,0 +1,59 @@
+<div class="ci-monitor">
+  <!-- Summary Bar -->
+  <div class="ci-summary">
+    <span class="summary-item passing">{{ passingCount }}/{{ repos.length }} passing</span>
+    <span class="summary-sep">|</span>
+    <span class="summary-item failing">{{ failingCount }} failing</span>
+    <span class="summary-sep">|</span>
+    <span class="summary-item in-progress">{{ inProgressCount }} deploying</span>
+  </div>
+
+  <!-- Filter Tabs -->
+  <div class="ci-filters">
+    <button
+      *ngFor="let f of filters"
+      class="filter-tab"
+      [class.active]="activeFilter === f.id"
+      (click)="setFilter(f.id)"
+    >
+      {{ f.label }}
+    </button>
+  </div>
+
+  <!-- Loading -->
+  <div class="ci-loading" *ngIf="loading">
+    <div class="spinner"></div>
+    <span>Loading CI status…</span>
+  </div>
+
+  <!-- Repo List -->
+  <div class="ci-list" *ngIf="!loading">
+    <div
+      *ngFor="let repo of filteredRepos"
+      class="ci-row"
+      [class.failed]="getStatus(repo) === 'failure'"
+      [class.in-progress]="getStatus(repo) === 'in_progress'"
+    >
+      <span class="status-dot">{{ getStatusDot(repo) }}</span>
+      <span class="repo-name">{{ repo.repoName }}</span>
+      <span class="workflow-name" *ngIf="repo.latestRun">{{ repo.latestRun.workflowName }}</span>
+      <span class="workflow-name dim" *ngIf="!repo.latestRun">—</span>
+      <span class="branch" *ngIf="repo.latestRun">{{ repo.latestRun.headBranch }}</span>
+      <span class="branch dim" *ngIf="!repo.latestRun">—</span>
+      <span class="status-label" [ngClass]="getStatusClass(repo)">{{ getStatusLabel(repo) }}</span>
+      <span class="time-ago" *ngIf="repo.latestRun">{{ timeAgo(repo.latestRun.updatedAt) }}</span>
+      <span class="time-ago" *ngIf="!repo.latestRun"></span>
+      <a
+        class="external-link"
+        [href]="repo.latestRun ? repo.latestRun.htmlUrl : repo.repoUrl"
+        target="_blank"
+        rel="noopener"
+        title="Open on GitHub"
+      >↗</a>
+    </div>
+
+    <div class="ci-empty" *ngIf="filteredRepos.length === 0">
+      No repos match this filter.
+    </div>
+  </div>
+</div>

--- a/src/app/components/command-center/ci-monitor/ci-monitor.component.scss
+++ b/src/app/components/command-center/ci-monitor/ci-monitor.component.scss
@@ -1,0 +1,204 @@
+$green: #00ffab;
+$red: #ff4d6a;
+$cyan: #00b4d8;
+$dim: #666;
+$bg: #0d0d0d;
+$card-bg: #141414;
+$border: #222;
+
+.ci-monitor {
+  padding: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.ci-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: $card-bg;
+  border: 1px solid $border;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+
+  .summary-item {
+    font-weight: 600;
+    &.passing { color: $green; }
+    &.failing { color: $red; }
+    &.in-progress { color: $cyan; }
+  }
+
+  .summary-sep {
+    color: $dim;
+  }
+}
+
+.ci-filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .filter-tab {
+    background: $card-bg;
+    border: 1px solid $border;
+    color: #999;
+    padding: 0.4rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.15s;
+
+    &:hover {
+      color: #fff;
+      border-color: #444;
+    }
+
+    &.active {
+      color: #fff;
+      border-color: $cyan;
+      background: rgba($cyan, 0.1);
+    }
+  }
+}
+
+.ci-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: $dim;
+  justify-content: center;
+
+  .spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid $border;
+    border-top-color: $cyan;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.ci-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ci-row {
+  display: grid;
+  grid-template-columns: 32px 1fr 1fr 100px 100px 80px 32px;
+  align-items: center;
+  padding: 0.7rem 1rem;
+  background: $card-bg;
+  border: 1px solid $border;
+  border-radius: 6px;
+  gap: 0.5rem;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: #333;
+    background: #1a1a1a;
+  }
+
+  &.failed {
+    border-left: 3px solid $red;
+    background: rgba($red, 0.05);
+  }
+
+  &.in-progress {
+    border-left: 3px solid $cyan;
+  }
+
+  .status-dot {
+    font-size: 1rem;
+    text-align: center;
+  }
+
+  .repo-name {
+    font-weight: 700;
+    color: #fff;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .workflow-name {
+    color: #aaa;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.dim { color: $dim; }
+  }
+
+  .branch {
+    color: $cyan;
+    font-size: 0.8rem;
+    font-family: monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.dim { color: $dim; }
+  }
+
+  .status-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+
+    &.success { color: $green; }
+    &.failure { color: $red; }
+    &.in_progress { color: $cyan; }
+    &.cancelled { color: #888; }
+    &.none { color: $dim; }
+  }
+
+  .time-ago {
+    color: $dim;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .external-link {
+    color: $dim;
+    text-decoration: none;
+    font-size: 1rem;
+    text-align: center;
+    transition: color 0.15s;
+
+    &:hover {
+      color: $cyan;
+    }
+  }
+}
+
+.ci-empty {
+  text-align: center;
+  padding: 2rem;
+  color: $dim;
+  font-size: 0.9rem;
+}
+
+// Responsive
+@media (max-width: 768px) {
+  .ci-row {
+    grid-template-columns: 28px 1fr auto 28px;
+
+    .workflow-name,
+    .branch,
+    .time-ago {
+      display: none;
+    }
+  }
+}

--- a/src/app/components/command-center/ci-monitor/ci-monitor.component.ts
+++ b/src/app/components/command-center/ci-monitor/ci-monitor.component.ts
@@ -1,0 +1,131 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription, interval } from 'rxjs';
+import { switchMap, startWith } from 'rxjs/operators';
+import {
+  WorkflowRunsService,
+  RepoCI,
+  CIStatus,
+} from '../../../services/workflow-runs.service';
+
+type FilterTab = 'all' | 'failing' | 'passing' | 'in_progress';
+
+@Component({
+  selector: 'app-ci-monitor',
+  templateUrl: './ci-monitor.component.html',
+  styleUrls: ['./ci-monitor.component.scss'],
+})
+export class CiMonitorComponent implements OnInit, OnDestroy {
+  repos: RepoCI[] = [];
+  loading = true;
+  activeFilter: FilterTab = 'all';
+  private sub?: Subscription;
+
+  filters: { id: FilterTab; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'failing', label: 'Failing' },
+    { id: 'passing', label: 'Passing' },
+    { id: 'in_progress', label: 'In Progress' },
+  ];
+
+  constructor(private workflowService: WorkflowRunsService) {}
+
+  ngOnInit(): void {
+    this.sub = interval(30000)
+      .pipe(
+        startWith(0),
+        switchMap(() => this.workflowService.getAllRepoCI())
+      )
+      .subscribe(repos => {
+        this.repos = this.sortRepos(repos);
+        this.loading = false;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  get filteredRepos(): RepoCI[] {
+    if (this.activeFilter === 'all') return this.repos;
+    return this.repos.filter(r => {
+      const status = this.getStatus(r);
+      switch (this.activeFilter) {
+        case 'failing': return status === 'failure';
+        case 'passing': return status === 'success';
+        case 'in_progress': return status === 'in_progress';
+        default: return true;
+      }
+    });
+  }
+
+  get passingCount(): number {
+    return this.repos.filter(r => this.getStatus(r) === 'success').length;
+  }
+
+  get failingCount(): number {
+    return this.repos.filter(r => this.getStatus(r) === 'failure').length;
+  }
+
+  get inProgressCount(): number {
+    return this.repos.filter(r => this.getStatus(r) === 'in_progress').length;
+  }
+
+  getStatus(repo: RepoCI): CIStatus {
+    return this.workflowService.getStatus(repo);
+  }
+
+  getStatusDot(repo: RepoCI): string {
+    switch (this.getStatus(repo)) {
+      case 'success': return '🟢';
+      case 'failure': return '🔴';
+      case 'in_progress': return '🟡';
+      case 'cancelled': return '⚫';
+      default: return '⚪';
+    }
+  }
+
+  getStatusLabel(repo: RepoCI): string {
+    switch (this.getStatus(repo)) {
+      case 'success': return 'SUCCESS';
+      case 'failure': return 'FAILED';
+      case 'in_progress': return 'IN PROGRESS';
+      case 'cancelled': return 'CANCELLED';
+      default: return 'No CI';
+    }
+  }
+
+  getStatusClass(repo: RepoCI): string {
+    return this.getStatus(repo);
+  }
+
+  timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ago`;
+  }
+
+  setFilter(filter: FilterTab): void {
+    this.activeFilter = filter;
+  }
+
+  private sortRepos(repos: RepoCI[]): RepoCI[] {
+    const order: Record<CIStatus, number> = {
+      failure: 0,
+      in_progress: 1,
+      success: 2,
+      cancelled: 3,
+      none: 4,
+    };
+    return repos.sort((a, b) => {
+      const aOrder = order[this.getStatus(a)] ?? 5;
+      const bOrder = order[this.getStatus(b)] ?? 5;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.repoName.localeCompare(b.repoName);
+    });
+  }
+}

--- a/src/app/components/command-center/command-center.component.html
+++ b/src/app/components/command-center/command-center.component.html
@@ -36,6 +36,6 @@
     <app-activity-log *ngIf="activeTab === 'activity'"></app-activity-log>
     <app-infra-dashboard *ngIf="activeTab === 'infra'"></app-infra-dashboard>
     <app-pixel-office *ngIf="activeTab === 'office'"></app-pixel-office>
-    <app-analytics-dashboard *ngIf="activeTab === 'analytics'"></app-analytics-dashboard>
+    <app-ci-monitor *ngIf="activeTab === 'ci'"></app-ci-monitor>
   </main>
 </div>

--- a/src/app/components/command-center/command-center.component.ts
+++ b/src/app/components/command-center/command-center.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 
-export type TabId = 'kanban' | 'files' | 'activity' | 'office' | 'infra' | 'analytics';
+export type TabId = 'kanban' | 'files' | 'activity' | 'office' | 'infra' | 'ci';
 
 /** Maps URL path segment → internal tab ID */
 const ROUTE_TO_TAB: Record<string, TabId> = {
@@ -12,7 +12,7 @@ const ROUTE_TO_TAB: Record<string, TabId> = {
   activity: 'activity',
   infra: 'infra',
   office: 'office',
-  analytics: 'analytics',
+  ci: 'ci',
 };
 
 /** Maps internal tab ID → URL path segment */
@@ -22,7 +22,7 @@ const TAB_TO_ROUTE: Record<TabId, string> = {
   activity: 'activity',
   infra: 'infra',
   office: 'office',
-  analytics: 'analytics',
+  ci: 'ci',
 };
 
 interface Tab {
@@ -45,7 +45,7 @@ export class CommandCenterComponent implements OnInit, OnDestroy {
     { id: 'activity', label: 'Activity', icon: '📊' },
     { id: 'infra', label: 'Infrastructure', icon: '🏗️' },
     { id: 'office', label: 'Office', icon: '🏢' },
-    { id: 'analytics', label: 'Analytics', icon: '📈' },
+    { id: 'ci', label: 'CI', icon: '🚀' },
   ];
 
   private routeSub?: Subscription;

--- a/src/app/components/command-center/releases/releases.component.html
+++ b/src/app/components/command-center/releases/releases.component.html
@@ -1,0 +1,139 @@
+<div class="releases-container">
+  <!-- Stats Header -->
+  <div class="stats-header">
+    <div class="stat-card">
+      <span class="stat-value">{{ releasesThisMonth }}</span>
+      <span class="stat-label">Releases This Month</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-value">{{ mostActiveRepo }}</span>
+      <span class="stat-label">Most Active Repo</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-value">{{ daysSinceLastRelease }}d</span>
+      <span class="stat-label">Since Last Release</span>
+    </div>
+  </div>
+
+  <!-- Filter Bar -->
+  <div class="filter-bar">
+    <div class="filter-group">
+      <label class="filter-label">Repos</label>
+      <div class="repo-filters">
+        <label *ngFor="let repo of repos" class="repo-checkbox">
+          <input
+            type="checkbox"
+            [checked]="selectedRepos.has(repo)"
+            (change)="toggleRepo(repo)"
+          />
+          <span class="repo-chip" [style.borderColor]="getRepoColor(repo)">
+            {{ repo }}
+          </span>
+        </label>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="filter-label">Date Range</label>
+      <div class="date-range-btns">
+        <button
+          *ngFor="let range of ['7d', '30d', '90d', 'all']"
+          [class.active]="dateRange === range"
+          (click)="setDateRange(range)"
+          class="range-btn"
+        >
+          {{ range === 'all' ? 'All' : range }}
+        </button>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="prerelease-toggle">
+        <input
+          type="checkbox"
+          [checked]="includePrerelease"
+          (change)="togglePrerelease()"
+        />
+        Include pre-releases
+      </label>
+    </div>
+  </div>
+
+  <!-- Loading -->
+  <div *ngIf="loading" class="loading">Loading releases...</div>
+  <div *ngIf="error" class="error">{{ error }}</div>
+
+  <!-- Timeline -->
+  <div class="timeline" *ngIf="!loading && !error">
+    <div
+      *ngFor="let item of timelineItems"
+      class="timeline-item"
+    >
+      <div class="timeline-marker" [style.backgroundColor]="getRepoColor(item.repo)"></div>
+      <div class="timeline-content">
+        <div class="timeline-header">
+          <span class="repo-badge" [style.backgroundColor]="getRepoColor(item.repo)">
+            {{ item.repo }}
+          </span>
+          <span class="version-tag" *ngIf="item.release">{{ item.release.tagName }}</span>
+          <span class="prerelease-badge" *ngIf="item.release?.isPrerelease">pre-release</span>
+          <span class="timeline-date">{{ formatDate(item.date) }}</span>
+        </div>
+
+        <h3 class="release-title" *ngIf="item.release">{{ item.release.name }}</h3>
+
+        <div class="release-body" *ngIf="item.release">
+          <p *ngIf="!isExpanded('r-' + item.release.id)">
+            {{ item.release.body | markdownPreview }}
+          </p>
+          <div *ngIf="isExpanded('r-' + item.release.id)" class="expanded-body">
+            {{ item.release.body }}
+          </div>
+          <button
+            *ngIf="item.release.body.length > 200"
+            class="expand-btn"
+            (click)="toggleExpand('r-' + item.release.id)"
+          >
+            {{ isExpanded('r-' + item.release.id) ? 'Show less' : 'Show more' }}
+          </button>
+        </div>
+
+        <div class="release-meta" *ngIf="item.release">
+          <img
+            *ngIf="item.release.author.avatarUrl"
+            [src]="item.release.author.avatarUrl"
+            [alt]="item.release.author.login"
+            class="author-avatar"
+          />
+          <span class="author-name">{{ item.release.author.login }}</span>
+          <a [href]="item.release.htmlUrl" target="_blank" class="github-link">
+            View on GitHub →
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div *ngIf="timelineItems.length === 0 && !loading" class="empty-state">
+      No releases match your filters.
+    </div>
+  </div>
+
+  <!-- PR Fallback Sections -->
+  <div *ngFor="let repoData of getReposWithPrFallback()" class="pr-fallback">
+    <button class="pr-section-header" (click)="togglePrSection(repoData.repo)">
+      <span class="repo-badge" [style.backgroundColor]="getRepoColor(repoData.repo)">
+        {{ repoData.repo }}
+      </span>
+      <span>Recent Changes (no formal releases)</span>
+      <span class="chevron">{{ expandedPrSections.has(repoData.repo) ? '▾' : '▸' }}</span>
+    </button>
+
+    <div [@expandCollapse]="expandedPrSections.has(repoData.repo) ? 'expanded' : 'collapsed'">
+      <div *ngFor="let pr of repoData.recentMergedPrs" class="pr-item">
+        <span class="pr-number">#{{ pr.number }}</span>
+        <a [href]="pr.htmlUrl" target="_blank" class="pr-title">{{ pr.title }}</a>
+        <span class="pr-meta">by {{ pr.author }} · {{ formatDate(pr.mergedAt) }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/command-center/releases/releases.component.scss
+++ b/src/app/components/command-center/releases/releases.component.scss
@@ -1,0 +1,307 @@
+.releases-container {
+  padding: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+  color: #e2e8f0;
+}
+
+// Stats Header
+.stats-header {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-card {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+
+  .stat-value {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .stat-label {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
+// Filter Bar
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.filter-label {
+  display: block;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.4rem;
+}
+
+.repo-filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.repo-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+
+  input { display: none; }
+
+  .repo-chip {
+    font-size: 0.8rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    border: 2px solid;
+    background: transparent;
+    transition: background 0.15s;
+  }
+
+  input:checked + .repo-chip {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.date-range-btns {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.range-btn {
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: all 0.15s;
+
+  &.active {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.3);
+  }
+}
+
+.prerelease-toggle {
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #94a3b8;
+}
+
+// Loading / Error
+.loading, .error, .empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.error { color: #f87171; }
+
+// Timeline
+.timeline {
+  position: relative;
+  padding-left: 2rem;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0.5rem;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -1.65rem;
+  top: 0.4rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.5);
+}
+
+.timeline-content {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.repo-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.version-tag {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  font-family: monospace;
+}
+
+.prerelease-badge {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+}
+
+.timeline-date {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-left: auto;
+}
+
+.release-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #f1f5f9;
+}
+
+.release-body {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  line-height: 1.5;
+
+  p { margin: 0; }
+}
+
+.expanded-body {
+  white-space: pre-wrap;
+  font-size: 0.85rem;
+}
+
+.expand-btn {
+  background: none;
+  border: none;
+  color: #60a5fa;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  margin-top: 0.25rem;
+
+  &:hover { text-decoration: underline; }
+}
+
+.release-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+}
+
+.author-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.author-name { color: #94a3b8; }
+
+.github-link {
+  color: #60a5fa;
+  text-decoration: none;
+  margin-left: auto;
+
+  &:hover { text-decoration: underline; }
+}
+
+// PR Fallback
+.pr-fallback {
+  margin-top: 1.5rem;
+}
+
+.pr-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  cursor: pointer;
+
+  .chevron { margin-left: auto; }
+}
+
+.pr-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem 0.5rem 2rem;
+  font-size: 0.85rem;
+}
+
+.pr-number {
+  font-family: monospace;
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.pr-title {
+  color: #60a5fa;
+  text-decoration: none;
+  &:hover { text-decoration: underline; }
+}
+
+.pr-meta {
+  color: #64748b;
+  font-size: 0.75rem;
+  margin-left: auto;
+  white-space: nowrap;
+}

--- a/src/app/components/command-center/releases/releases.component.ts
+++ b/src/app/components/command-center/releases/releases.component.ts
@@ -1,0 +1,194 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { ReleasesService, RepoReleases, Release, MergedPr } from '../../../services/releases.service';
+
+const REPO_COLORS: Record<string, string> = {
+  'Float': '#00b4d8',
+  'xomfit-ios': '#22c55e',
+  'xomify-frontend': '#a855f7',
+  'xomware-frontend': '#f97316',
+};
+
+interface TimelineItem {
+  type: 'release' | 'pr';
+  repo: string;
+  date: string;
+  release?: Release;
+  pr?: MergedPr;
+}
+
+@Component({
+  selector: 'app-releases',
+  templateUrl: './releases.component.html',
+  styleUrls: ['./releases.component.scss'],
+  animations: [
+    trigger('expandCollapse', [
+      state('collapsed', style({ height: '0', overflow: 'hidden', opacity: 0 })),
+      state('expanded', style({ height: '*', overflow: 'visible', opacity: 1 })),
+      transition('collapsed <=> expanded', animate('200ms ease-in-out')),
+    ]),
+  ],
+})
+export class ReleasesComponent implements OnInit, OnDestroy {
+  allData: RepoReleases[] = [];
+  timelineItems: TimelineItem[] = [];
+  loading = true;
+  error = '';
+
+  // Filters
+  repos = Object.keys(REPO_COLORS);
+  selectedRepos: Set<string> = new Set(this.repos);
+  includePrerelease = false;
+  dateRange: '7d' | '30d' | '90d' | 'all' = 'all';
+
+  // Stats
+  releasesThisMonth = 0;
+  mostActiveRepo = '';
+  daysSinceLastRelease = 0;
+
+  // Expand state
+  expandedIds = new Set<string>();
+  expandedPrSections = new Set<string>();
+
+  private refreshInterval: any;
+
+  constructor(private releasesService: ReleasesService) {}
+
+  ngOnInit(): void {
+    this.loadReleases();
+    this.refreshInterval = setInterval(() => this.loadReleases(), 5 * 60 * 1000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.refreshInterval) clearInterval(this.refreshInterval);
+  }
+
+  loadReleases(): void {
+    this.loading = true;
+    this.releasesService.getReleases().subscribe({
+      next: data => {
+        this.allData = data;
+        this.applyFilters();
+        this.computeStats();
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load releases';
+        this.loading = false;
+      },
+    });
+  }
+
+  toggleRepo(repo: string): void {
+    if (this.selectedRepos.has(repo)) {
+      this.selectedRepos.delete(repo);
+    } else {
+      this.selectedRepos.add(repo);
+    }
+    this.applyFilters();
+  }
+
+  setDateRange(range: '7d' | '30d' | '90d' | 'all'): void {
+    this.dateRange = range;
+    this.applyFilters();
+  }
+
+  togglePrerelease(): void {
+    this.includePrerelease = !this.includePrerelease;
+    this.applyFilters();
+  }
+
+  toggleExpand(id: string): void {
+    if (this.expandedIds.has(id)) {
+      this.expandedIds.delete(id);
+    } else {
+      this.expandedIds.add(id);
+    }
+  }
+
+  togglePrSection(repo: string): void {
+    if (this.expandedPrSections.has(repo)) {
+      this.expandedPrSections.delete(repo);
+    } else {
+      this.expandedPrSections.add(repo);
+    }
+  }
+
+  isExpanded(id: string): boolean {
+    return this.expandedIds.has(id);
+  }
+
+  getRepoColor(repo: string): string {
+    return REPO_COLORS[repo] || '#6b7280';
+  }
+
+  getDateCutoff(): Date | null {
+    if (this.dateRange === 'all') return null;
+    const days = parseInt(this.dateRange);
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  }
+
+  applyFilters(): void {
+    const cutoff = this.getDateCutoff();
+    const items: TimelineItem[] = [];
+
+    for (const repoData of this.allData) {
+      if (!this.selectedRepos.has(repoData.repo)) continue;
+
+      for (const release of repoData.releases) {
+        if (!this.includePrerelease && release.isPrerelease) continue;
+        if (cutoff && new Date(release.publishedAt) < cutoff) continue;
+        items.push({
+          type: 'release',
+          repo: repoData.repo,
+          date: release.publishedAt,
+          release,
+        });
+      }
+    }
+
+    items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    this.timelineItems = items;
+  }
+
+  computeStats(): void {
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const repoCounts: Record<string, number> = {};
+    let latestDate: Date | null = null;
+    let totalThisMonth = 0;
+
+    for (const repoData of this.allData) {
+      repoCounts[repoData.repo] = repoData.releases.length;
+      for (const release of repoData.releases) {
+        const d = new Date(release.publishedAt);
+        if (d >= monthStart) totalThisMonth++;
+        if (!latestDate || d > latestDate) latestDate = d;
+      }
+    }
+
+    this.releasesThisMonth = totalThisMonth;
+    this.mostActiveRepo = Object.entries(repoCounts)
+      .sort(([, a], [, b]) => b - a)[0]?.[0] || 'N/A';
+
+    if (latestDate) {
+      this.daysSinceLastRelease = Math.floor(
+        (now.getTime() - latestDate.getTime()) / (1000 * 60 * 60 * 24)
+      );
+    }
+  }
+
+  getReposWithPrFallback(): RepoReleases[] {
+    return this.allData.filter(
+      r => this.selectedRepos.has(r.repo) && r.recentMergedPrs && r.recentMergedPrs.length > 0
+    );
+  }
+
+  formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+}

--- a/src/app/pipes/markdown-preview.pipe.ts
+++ b/src/app/pipes/markdown-preview.pipe.ts
@@ -1,0 +1,42 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'markdownPreview' })
+export class MarkdownPreviewPipe implements PipeTransform {
+  transform(value: string, maxLength: number = 200): string {
+    if (!value) return '';
+
+    let text = value
+      // Remove code blocks
+      .replace(/```[\s\S]*?```/g, '')
+      // Remove inline code
+      .replace(/`([^`]+)`/g, '$1')
+      // Remove images
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+      // Remove links, keep text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // Remove headers
+      .replace(/^#{1,6}\s+/gm, '')
+      // Remove bold/italic
+      .replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1')
+      .replace(/_{1,3}([^_]+)_{1,3}/g, '$1')
+      // Remove strikethrough
+      .replace(/~~([^~]+)~~/g, '$1')
+      // Remove blockquotes
+      .replace(/^>\s+/gm, '')
+      // Remove horizontal rules
+      .replace(/^[-*_]{3,}\s*$/gm, '')
+      // Remove list markers
+      .replace(/^[\s]*[-*+]\s+/gm, '')
+      .replace(/^[\s]*\d+\.\s+/gm, '')
+      // Collapse whitespace
+      .replace(/\n{2,}/g, ' ')
+      .replace(/\n/g, ' ')
+      .trim();
+
+    if (text.length > maxLength) {
+      text = text.substring(0, maxLength) + '…';
+    }
+
+    return text;
+  }
+}

--- a/src/app/services/releases.service.ts
+++ b/src/app/services/releases.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth.service';
+import { Observable, of, from, forkJoin } from 'rxjs';
+import { map, tap, shareReplay } from 'rxjs/operators';
+
+export interface Release {
+  id: number;
+  tagName: string;
+  name: string;
+  body: string;
+  publishedAt: string;
+  htmlUrl: string;
+  author: { login: string; avatarUrl: string };
+  isPrerelease: boolean;
+  isDraft: boolean;
+}
+
+export interface MergedPr {
+  number: number;
+  title: string;
+  mergedAt: string;
+  htmlUrl: string;
+  author: string;
+}
+
+export interface RepoReleases {
+  repo: string;
+  releases: Release[];
+  recentMergedPrs?: MergedPr[];
+}
+
+const REPOS = ['Float', 'xomfit-ios', 'xomify-frontend', 'xomware-frontend'];
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+@Injectable({ providedIn: 'root' })
+export class ReleasesService {
+  private cache: RepoReleases[] | null = null;
+  private cacheTimestamp = 0;
+
+  constructor(private auth: AuthService) {}
+
+  private get headers(): HeadersInit {
+    return {
+      'Accept': 'application/vnd.github+json',
+      'X-Auth-Hash': this.auth.getPassphraseHash(),
+    };
+  }
+
+  getReleases(): Observable<RepoReleases[]> {
+    const now = Date.now();
+    if (this.cache && (now - this.cacheTimestamp) < CACHE_TTL) {
+      return of(this.cache);
+    }
+
+    const requests = REPOS.map(repo =>
+      from(this.fetchRepoReleases(repo))
+    );
+
+    return forkJoin(requests).pipe(
+      tap(results => {
+        this.cache = results;
+        this.cacheTimestamp = Date.now();
+      })
+    );
+  }
+
+  getRecentMergedPrs(repo: string, days: number = 30): Observable<MergedPr[]> {
+    return from(this.fetchMergedPrs(repo, days));
+  }
+
+  clearCache(): void {
+    this.cache = null;
+    this.cacheTimestamp = 0;
+  }
+
+  private async fetchRepoReleases(repo: string): Promise<RepoReleases> {
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/Xomware/${repo}/releases?per_page=50`,
+        { headers: this.headers }
+      );
+
+      if (!res.ok) {
+        return { repo, releases: [], recentMergedPrs: await this.fetchMergedPrs(repo, 30) };
+      }
+
+      const data = await res.json();
+      const releases: Release[] = (data || [])
+        .filter((r: any) => !r.draft)
+        .map((r: any) => ({
+          id: r.id,
+          tagName: r.tag_name,
+          name: r.name || r.tag_name,
+          body: r.body || '',
+          publishedAt: r.published_at,
+          htmlUrl: r.html_url,
+          author: {
+            login: r.author?.login || 'unknown',
+            avatarUrl: r.author?.avatar_url || '',
+          },
+          isPrerelease: r.prerelease,
+          isDraft: false,
+        }));
+
+      const result: RepoReleases = { repo, releases };
+      if (releases.length === 0) {
+        result.recentMergedPrs = await this.fetchMergedPrs(repo, 30);
+      }
+      return result;
+    } catch {
+      return { repo, releases: [], recentMergedPrs: await this.fetchMergedPrs(repo, 30) };
+    }
+  }
+
+  private async fetchMergedPrs(repo: string, days: number): Promise<MergedPr[]> {
+    try {
+      const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      const res = await fetch(
+        `https://api.github.com/repos/Xomware/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=20`,
+        { headers: this.headers }
+      );
+
+      if (!res.ok) return [];
+
+      const data = await res.json();
+      return (data || [])
+        .filter((pr: any) => pr.merged_at && pr.merged_at >= since)
+        .slice(0, 5)
+        .map((pr: any) => ({
+          number: pr.number,
+          title: pr.title,
+          mergedAt: pr.merged_at,
+          htmlUrl: pr.html_url,
+          author: pr.user?.login || 'unknown',
+        }));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/app/services/workflow-runs.service.ts
+++ b/src/app/services/workflow-runs.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import { Observable, of, timer, from, concat } from 'rxjs';
+import { map, switchMap, shareReplay, catchError, concatMap, delay, toArray } from 'rxjs/operators';
+
+export interface WorkflowRun {
+  repoName: string;
+  workflowName: string;
+  status: string;
+  conclusion: string | null;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  headBranch: string;
+}
+
+export interface RepoCI {
+  repoName: string;
+  repoUrl: string;
+  latestRun: WorkflowRun | null;
+  loading: boolean;
+}
+
+export type CIStatus = 'success' | 'failure' | 'cancelled' | 'in_progress' | 'none';
+
+@Injectable({ providedIn: 'root' })
+export class WorkflowRunsService {
+  private reposCache$: Observable<any[]> | null = null;
+  private reposCacheTime = 0;
+  private runCache = new Map<string, { data: WorkflowRun | null; time: number }>();
+  private readonly CACHE_TTL = 30000;
+
+  getRepos(): Observable<any[]> {
+    const now = Date.now();
+    if (this.reposCache$ && now - this.reposCacheTime < this.CACHE_TTL) {
+      return this.reposCache$;
+    }
+    this.reposCacheTime = now;
+    this.reposCache$ = from(
+      fetch('https://api.github.com/orgs/Xomware/repos?per_page=100')
+        .then(r => r.json())
+    ).pipe(
+      map((repos: any[]) =>
+        repos
+          .filter((r: any) => !r.archived && !r.fork)
+          .sort((a: any, b: any) => a.name.localeCompare(b.name))
+      ),
+      shareReplay(1),
+      catchError(() => of([]))
+    );
+    return this.reposCache$;
+  }
+
+  getLatestWorkflowRun(repo: string): Observable<WorkflowRun | null> {
+    const now = Date.now();
+    const cached = this.runCache.get(repo);
+    if (cached && now - cached.time < this.CACHE_TTL) {
+      return of(cached.data);
+    }
+
+    return from(
+      fetch(`https://api.github.com/repos/Xomware/${repo}/actions/runs?per_page=3`)
+        .then(r => r.json())
+    ).pipe(
+      map((data: any) => {
+        const runs = data.workflow_runs;
+        if (!runs || runs.length === 0) {
+          this.runCache.set(repo, { data: null, time: Date.now() });
+          return null;
+        }
+        const run = runs[0];
+        const result: WorkflowRun = {
+          repoName: repo,
+          workflowName: run.name,
+          status: run.status,
+          conclusion: run.conclusion,
+          htmlUrl: run.html_url,
+          createdAt: run.created_at,
+          updatedAt: run.updated_at,
+          headBranch: run.head_branch,
+        };
+        this.runCache.set(repo, { data: result, time: Date.now() });
+        return result;
+      }),
+      catchError(() => {
+        this.runCache.set(repo, { data: null, time: Date.now() });
+        return of(null);
+      })
+    );
+  }
+
+  getAllRepoCI(): Observable<RepoCI[]> {
+    return this.getRepos().pipe(
+      switchMap((repos: any[]) => {
+        if (repos.length === 0) return of([]);
+        // Sequential with 200ms delay
+        const requests = repos.map((repo: any) =>
+          this.getLatestWorkflowRun(repo.name).pipe(
+            map(run => ({
+              repoName: repo.name,
+              repoUrl: repo.html_url,
+              latestRun: run,
+              loading: false,
+            } as RepoCI)),
+            delay(200)
+          )
+        );
+        return concat(...requests).pipe(toArray());
+      })
+    );
+  }
+
+  getStatus(repo: RepoCI): CIStatus {
+    if (!repo.latestRun) return 'none';
+    if (repo.latestRun.status === 'in_progress' || repo.latestRun.status === 'queued') return 'in_progress';
+    if (repo.latestRun.conclusion === 'success') return 'success';
+    if (repo.latestRun.conclusion === 'failure') return 'failure';
+    if (repo.latestRun.conclusion === 'cancelled') return 'cancelled';
+    return 'none';
+  }
+}


### PR DESCRIPTION
## Summary
Adds a CI/CD Monitor tab to the Command Center showing real-time GitHub Actions workflow status across all Xomware repos.

### Features
- **Summary bar**: X/Y passing | N failing | M deploying
- **Filter tabs**: All, Failing, Passing, In Progress
- **Sorted repo list**: failing first → in progress → passing → no CI
- **Auto-refresh** every 30s
- **Failed repo highlighting**: red left border + subtle red tint
- **Rate-limit friendly**: sequential requests with 200ms delay, 30s cache TTL
- **Responsive**: collapses gracefully on mobile

### New Files
- `WorkflowRunsService` — fetches repos + workflow runs from GitHub API (public, no auth)
- `CiMonitorComponent` — the CI monitor view
- `/ci` route redirect + CI tab in nav

### Access
Navigate to `/command/ci` or click the 🚀 CI tab.

Closes #58