### PR TITLE
feat: Issue Board — open GitHub issues across all repos (#59)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { TicketDetailModalComponent } from './components/command-center/ticket-d
 import { AnalyticsDashboardComponent } from './components/command-center/analytics-dashboard/analytics-dashboard.component';
 
 // Standalone feature views
+import { IssueBoardComponent } from './components/command-center/issue-board/issue-board.component';
 import { CiMonitorComponent } from './components/command-center/ci-monitor/ci-monitor.component';
 import { PrDashboardComponent } from './components/pr-dashboard/pr-dashboard.component';
 
@@ -62,6 +63,7 @@ import { PrDashboardComponent } from './components/pr-dashboard/pr-dashboard.com
     AnalyticsDashboardComponent,
     // Standalone views
     PrDashboardComponent,
+    IssueBoardComponent,
     CiMonitorComponent,
   ],
   imports: [

--- a/src/app/components/command-center/command-center.component.html
+++ b/src/app/components/command-center/command-center.component.html
@@ -36,6 +36,6 @@
     <app-activity-log *ngIf="activeTab === 'activity'"></app-activity-log>
     <app-infra-dashboard *ngIf="activeTab === 'infra'"></app-infra-dashboard>
     <app-pixel-office *ngIf="activeTab === 'office'"></app-pixel-office>
-    <app-ci-monitor *ngIf="activeTab === 'ci'"></app-ci-monitor>
+    <app-issue-board *ngIf="activeTab === 'issues'"></app-issue-board>
   </main>
 </div>

--- a/src/app/components/command-center/command-center.component.ts
+++ b/src/app/components/command-center/command-center.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 
-export type TabId = 'kanban' | 'files' | 'activity' | 'office' | 'infra' | 'ci';
+export type TabId = 'kanban' | 'files' | 'activity' | 'office' | 'infra' | 'issues';
 
 /** Maps URL path segment → internal tab ID */
 const ROUTE_TO_TAB: Record<string, TabId> = {
@@ -12,7 +12,7 @@ const ROUTE_TO_TAB: Record<string, TabId> = {
   activity: 'activity',
   infra: 'infra',
   office: 'office',
-  ci: 'ci',
+  issues: 'issues',
 };
 
 /** Maps internal tab ID → URL path segment */
@@ -22,7 +22,7 @@ const TAB_TO_ROUTE: Record<TabId, string> = {
   activity: 'activity',
   infra: 'infra',
   office: 'office',
-  ci: 'ci',
+  issues: 'issues',
 };
 
 interface Tab {
@@ -45,7 +45,7 @@ export class CommandCenterComponent implements OnInit, OnDestroy {
     { id: 'activity', label: 'Activity', icon: '📊' },
     { id: 'infra', label: 'Infrastructure', icon: '🏗️' },
     { id: 'office', label: 'Office', icon: '🏢' },
-    { id: 'ci', label: 'CI', icon: '🚀' },
+    { id: 'issues', label: 'Issues', icon: '🐛' },
   ];
 
   private routeSub?: Subscription;

--- a/src/app/components/command-center/issue-board/issue-board.component.html
+++ b/src/app/components/command-center/issue-board/issue-board.component.html
@@ -1,0 +1,117 @@
+<div class="issue-board">
+  <!-- Summary Bar -->
+  <div class="summary-bar">
+    <div class="summary-stat">
+      <span class="stat-value">{{ totalIssues }}</span>
+      <span class="stat-label">open issues</span>
+    </div>
+    <div class="summary-divider"></div>
+    <div class="summary-stat">
+      <span class="stat-value bug">{{ bugCount }}</span>
+      <span class="stat-label">bugs</span>
+    </div>
+    <div class="summary-divider"></div>
+    <div class="summary-stat">
+      <span class="stat-value unassigned">{{ unassignedCount }}</span>
+      <span class="stat-label">unassigned</span>
+    </div>
+    <div class="summary-divider"></div>
+    <div class="summary-stat">
+      <span class="stat-value feature">{{ featureCount }}</span>
+      <span class="stat-label">features</span>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div class="controls">
+    <div class="filter-tabs">
+      <button
+        *ngFor="let f of filters"
+        class="filter-tab"
+        [class.active]="activeFilter === f.id"
+        (click)="setFilter(f.id)"
+      >
+        {{ f.label }}
+      </button>
+    </div>
+    <select class="sort-select" [(ngModel)]="sortMode">
+      <option value="newest">Newest</option>
+      <option value="oldest">Oldest</option>
+      <option value="comments">Most Comments</option>
+    </select>
+  </div>
+
+  <!-- Loading -->
+  <div class="loading-state" *ngIf="loading">
+    <div class="spinner"></div>
+    <span>Loading issues across all repos…</span>
+  </div>
+
+  <!-- Empty State -->
+  <div class="empty-state" *ngIf="!loading && filteredRepoIssues.length === 0">
+    <span>No issues match the selected filter</span>
+  </div>
+
+  <!-- Repo Sections -->
+  <div class="repo-sections" *ngIf="!loading">
+    <div class="repo-section" *ngFor="let repo of filteredRepoIssues">
+      <div class="repo-header" (click)="toggleRepo(repo.repo)">
+        <span class="repo-chevron" [class.collapsed]="isCollapsed(repo.repo)">▸</span>
+        <span class="repo-name">{{ repo.repo }}</span>
+        <span class="repo-count">{{ repo.issues.length }}</span>
+      </div>
+
+      <div class="issue-list" *ngIf="!isCollapsed(repo.repo)">
+        <a
+          class="issue-row"
+          *ngFor="let issue of repo.issues"
+          [href]="issue.html_url"
+          target="_blank"
+          rel="noopener"
+        >
+          <span class="issue-number">#{{ issue.number }}</span>
+
+          <div class="issue-main">
+            <div class="issue-title">{{ issue.title }}</div>
+            <div class="issue-meta">
+              <span
+                class="label-chip"
+                *ngFor="let label of getVisibleLabels(issue)"
+                [style.background]="'#' + label.color + '20'"
+                [style.border-color]="'#' + label.color"
+                [style.color]="'#' + label.color"
+              >
+                {{ label.name }}
+              </span>
+              <span class="label-more" *ngIf="getExtraLabelCount(issue) > 0">
+                +{{ getExtraLabelCount(issue) }} more
+              </span>
+            </div>
+          </div>
+
+          <div class="issue-right">
+            <div class="issue-assignee" *ngIf="issue.assignee">
+              <img
+                [src]="issue.assignee.avatar_url"
+                [alt]="issue.assignee.login"
+                class="avatar"
+              />
+              <span class="assignee-name">{{ issue.assignee.login }}</span>
+            </div>
+            <div class="issue-assignee unassigned-text" *ngIf="!issue.assignee">
+              <span class="assignee-name muted">Unassigned</span>
+            </div>
+
+            <div class="issue-comments">
+              <span class="comment-icon">💬</span>
+              <span>{{ issue.comments }}</span>
+            </div>
+
+            <span class="issue-age">{{ timeAgo(issue.created_at) }}</span>
+            <span class="external-link">↗</span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/command-center/issue-board/issue-board.component.scss
+++ b/src/app/components/command-center/issue-board/issue-board.component.scss
@@ -1,0 +1,343 @@
+@import 'styles/variables';
+
+.issue-board {
+  padding: $spacing-lg;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+// Summary Bar
+.summary-bar {
+  display: flex;
+  align-items: center;
+  gap: $spacing-lg;
+  padding: $spacing-md $spacing-lg;
+  background: rgba($bg-card, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-lg;
+  margin-bottom: $spacing-lg;
+}
+
+.summary-stat {
+  display: flex;
+  align-items: baseline;
+  gap: $spacing-xs;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: $brand-cyan;
+
+  &.bug { color: #e74c3c; }
+  &.unassigned { color: $text-secondary; }
+  &.feature { color: #00ffab; }
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.summary-divider {
+  width: 1px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+// Controls
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: $spacing-lg;
+  gap: $spacing-md;
+}
+
+.filter-tabs {
+  display: flex;
+  gap: $spacing-xs;
+}
+
+.filter-tab {
+  padding: $spacing-sm $spacing-md;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: $radius-md;
+  color: $text-secondary;
+  font-size: 0.85rem;
+  font-family: $font-stack;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: $text-primary;
+  }
+
+  &.active {
+    background: rgba($brand-cyan, 0.1);
+    border-color: rgba($brand-cyan, 0.3);
+    color: $brand-cyan;
+  }
+}
+
+.sort-select {
+  padding: $spacing-sm $spacing-md;
+  background: $bg-card;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: 0.85rem;
+  font-family: $font-stack;
+  cursor: pointer;
+
+  option {
+    background: $bg-card;
+    color: $text-primary;
+  }
+}
+
+// Loading
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-md;
+  padding: $spacing-2xl;
+  color: $text-secondary;
+  font-size: 0.9rem;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba($brand-cyan, 0.2);
+  border-top-color: $brand-cyan;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+// Empty State
+.empty-state {
+  text-align: center;
+  padding: $spacing-2xl;
+  color: $text-secondary;
+  font-size: 0.95rem;
+}
+
+// Repo Sections
+.repo-section {
+  margin-bottom: $spacing-md;
+  background: rgba($bg-card, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-lg;
+  overflow: hidden;
+}
+
+.repo-header {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  cursor: pointer;
+  user-select: none;
+  transition: background $transition-fast;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}
+
+.repo-chevron {
+  color: $text-muted;
+  font-size: 0.9rem;
+  transition: transform $transition-fast;
+  display: inline-block;
+  transform: rotate(90deg);
+
+  &.collapsed {
+    transform: rotate(0deg);
+  }
+}
+
+.repo-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $text-primary;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.repo-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: $brand-cyan;
+  background: rgba($brand-cyan, 0.1);
+  border: 1px solid rgba($brand-cyan, 0.2);
+  border-radius: 10px;
+  padding: 1px 8px;
+  margin-left: auto;
+}
+
+// Issue List
+.issue-list {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.issue-row {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-md;
+  padding: $spacing-sm $spacing-md;
+  text-decoration: none;
+  color: inherit;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  transition: background $transition-fast;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}
+
+.issue-number {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  color: $text-muted;
+  min-width: 40px;
+  padding-top: 2px;
+}
+
+.issue-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.issue-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: $text-primary;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.4;
+  margin-bottom: 4px;
+}
+
+.issue-meta {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  flex-wrap: wrap;
+}
+
+.label-chip {
+  font-size: 0.7rem;
+  padding: 1px 8px;
+  border-radius: 10px;
+  border: 1px solid;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.label-more {
+  font-size: 0.7rem;
+  color: $text-muted;
+}
+
+.issue-right {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  flex-shrink: 0;
+}
+
+.issue-assignee {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  min-width: 120px;
+}
+
+.avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.assignee-name {
+  font-size: 0.8rem;
+  color: $text-secondary;
+
+  &.muted {
+    color: $text-muted;
+    font-style: italic;
+  }
+}
+
+.issue-comments {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.8rem;
+  color: $text-secondary;
+  min-width: 36px;
+}
+
+.comment-icon {
+  font-size: 0.75rem;
+}
+
+.issue-age {
+  font-size: 0.75rem;
+  color: $text-muted;
+  min-width: 56px;
+  text-align: right;
+}
+
+.external-link {
+  font-size: 0.85rem;
+  color: $text-muted;
+  opacity: 0;
+  transition: opacity $transition-fast;
+
+  .issue-row:hover & {
+    opacity: 1;
+  }
+}
+
+// Responsive
+@media (max-width: $breakpoint-md) {
+  .summary-bar {
+    flex-wrap: wrap;
+    gap: $spacing-md;
+  }
+
+  .summary-divider {
+    display: none;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .issue-right {
+    flex-wrap: wrap;
+    gap: $spacing-sm;
+  }
+
+  .issue-assignee {
+    min-width: auto;
+  }
+}

--- a/src/app/components/command-center/issue-board/issue-board.component.ts
+++ b/src/app/components/command-center/issue-board/issue-board.component.ts
@@ -1,0 +1,158 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { IssuesService, RepoIssues, GitHubIssue } from '../../../services/issues.service';
+
+type FilterTab = 'all' | 'bugs' | 'features' | 'unassigned' | 'jarvis';
+type SortMode = 'newest' | 'oldest' | 'comments';
+
+@Component({
+  selector: 'app-issue-board',
+  templateUrl: './issue-board.component.html',
+  styleUrls: ['./issue-board.component.scss'],
+})
+export class IssueBoardComponent implements OnInit, OnDestroy {
+  repoIssues: RepoIssues[] = [];
+  loading = true;
+  activeFilter: FilterTab = 'all';
+  sortMode: SortMode = 'newest';
+  collapsedRepos = new Set<string>();
+
+  private refreshTimer?: ReturnType<typeof setInterval>;
+
+  totalIssues = 0;
+  bugCount = 0;
+  unassignedCount = 0;
+  featureCount = 0;
+
+  filters: { id: FilterTab; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'bugs', label: 'Bugs' },
+    { id: 'features', label: 'Features' },
+    { id: 'unassigned', label: 'Unassigned' },
+    { id: 'jarvis', label: 'Jarvis' },
+  ];
+
+  constructor(private issuesService: IssuesService) {}
+
+  ngOnInit(): void {
+    this.loadIssues();
+    this.refreshTimer = setInterval(() => this.loadIssues(), 120_000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
+  }
+
+  async loadIssues(): Promise<void> {
+    this.loading = true;
+    try {
+      this.repoIssues = await this.issuesService.fetchAllIssues();
+      this.computeStats();
+    } catch {
+      this.repoIssues = [];
+    }
+    this.loading = false;
+  }
+
+  private computeStats(): void {
+    const all = this.allIssues;
+    this.totalIssues = all.length;
+    this.bugCount = all.filter(i => this.isBug(i)).length;
+    this.unassignedCount = all.filter(i => !i.assignee).length;
+    this.featureCount = all.filter(i => this.isFeature(i)).length;
+  }
+
+  get allIssues(): GitHubIssue[] {
+    return this.repoIssues.flatMap(r => r.issues);
+  }
+
+  get filteredRepoIssues(): RepoIssues[] {
+    return this.repoIssues
+      .map(r => ({ repo: r.repo, issues: this.filterIssues(r.issues) }))
+      .filter(r => r.issues.length > 0);
+  }
+
+  get totalFiltered(): number {
+    return this.filteredRepoIssues.reduce((sum, r) => sum + r.issues.length, 0);
+  }
+
+  private filterIssues(issues: GitHubIssue[]): GitHubIssue[] {
+    let filtered = issues;
+    switch (this.activeFilter) {
+      case 'bugs':
+        filtered = issues.filter(i => this.isBug(i));
+        break;
+      case 'features':
+        filtered = issues.filter(i => this.isFeature(i));
+        break;
+      case 'unassigned':
+        filtered = issues.filter(i => !i.assignee);
+        break;
+      case 'jarvis':
+        filtered = issues.filter(i => i.assignee?.login === 'JarvisXomware');
+        break;
+    }
+    return this.sortIssues(filtered);
+  }
+
+  private sortIssues(issues: GitHubIssue[]): GitHubIssue[] {
+    const sorted = [...issues];
+    switch (this.sortMode) {
+      case 'newest':
+        sorted.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+        break;
+      case 'oldest':
+        sorted.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+        break;
+      case 'comments':
+        sorted.sort((a, b) => b.comments - a.comments);
+        break;
+    }
+    return sorted;
+  }
+
+  isBug(issue: GitHubIssue): boolean {
+    return issue.labels.some(l => l.name.toLowerCase().includes('bug'));
+  }
+
+  isFeature(issue: GitHubIssue): boolean {
+    return issue.labels.some(l =>
+      l.name.toLowerCase().includes('enhancement') || l.name.toLowerCase().includes('feature')
+    );
+  }
+
+  toggleRepo(repo: string): void {
+    if (this.collapsedRepos.has(repo)) {
+      this.collapsedRepos.delete(repo);
+    } else {
+      this.collapsedRepos.add(repo);
+    }
+  }
+
+  isCollapsed(repo: string): boolean {
+    return this.collapsedRepos.has(repo);
+  }
+
+  setFilter(filter: FilterTab): void {
+    this.activeFilter = filter;
+  }
+
+  getVisibleLabels(issue: GitHubIssue): { name: string; color: string }[] {
+    return issue.labels.slice(0, 3);
+  }
+
+  getExtraLabelCount(issue: GitHubIssue): number {
+    return Math.max(0, issue.labels.length - 3);
+  }
+
+  timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    const months = Math.floor(days / 30);
+    return `${months}mo ago`;
+  }
+}

--- a/src/app/services/issues.service.ts
+++ b/src/app/services/issues.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+
+export interface GitHubIssueLabel {
+  name: string;
+  color: string;
+}
+
+export interface GitHubIssueAssignee {
+  login: string;
+  avatar_url: string;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  labels: GitHubIssueLabel[];
+  assignee: GitHubIssueAssignee | null;
+  created_at: string;
+  comments: number;
+  html_url: string;
+  pull_request?: unknown;
+  repository_url: string;
+}
+
+export interface RepoIssues {
+  repo: string;
+  issues: GitHubIssue[];
+}
+
+interface CacheEntry {
+  data: GitHubIssue[];
+  timestamp: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class IssuesService {
+  private readonly API = 'https://api.github.com';
+  private readonly ORG = 'Xomware';
+  private readonly CACHE_TTL = 120_000;
+  private readonly DELAY = 300;
+
+  private cache = new Map<string, CacheEntry>();
+
+  async fetchAllIssues(): Promise<RepoIssues[]> {
+    const repos = await this.fetchRepos();
+    const results: RepoIssues[] = [];
+
+    for (let i = 0; i < repos.length; i++) {
+      const repo = repos[i];
+      if (i > 0) await this.delay(this.DELAY);
+      const issues = await this.fetchRepoIssues(repo);
+      if (issues.length > 0) {
+        results.push({ repo, issues });
+      }
+    }
+
+    results.sort((a, b) => b.issues.length - a.issues.length);
+    return results;
+  }
+
+  private async fetchRepos(): Promise<string[]> {
+    try {
+      const res = await fetch(`${this.API}/orgs/${this.ORG}/repos?per_page=100`, {
+        headers: { Accept: 'application/vnd.github.v3+json' },
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return data.map((r: { name: string }) => r.name).sort();
+    } catch {
+      return [];
+    }
+  }
+
+  private async fetchRepoIssues(repo: string): Promise<GitHubIssue[]> {
+    const cached = this.cache.get(repo);
+    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
+      return cached.data;
+    }
+
+    try {
+      const res = await fetch(
+        `${this.API}/repos/${this.ORG}/${repo}/issues?state=open&per_page=100`,
+        { headers: { Accept: 'application/vnd.github.v3+json' } }
+      );
+      if (!res.ok) return [];
+      const data: GitHubIssue[] = await res.json();
+      const issues = data.filter(i => !i.pull_request);
+      this.cache.set(repo, { data: issues, timestamp: Date.now() });
+      return issues;
+    } catch {
+      return [];
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
## Summary
Adds an **Issue Board** tab to the Command Center at `/command/issues`, showing all open GitHub issues across every Xomware repo.

## Features
- **Summary bar**: Total open issues, bugs, unassigned, feature requests
- **Filter tabs**: All | Bugs | Features | Unassigned | Jarvis
- **Sort**: Newest | Oldest | Most Comments
- **Collapsible repo sections** with issue count badges
- **Label color chips** using GitHub API label colors
- **Assignee display** with avatar + username
- **Comment count** and relative time ago
- **Auto-refresh** every 120s
- **120s cache** per repo, sequential requests with 300ms delay to respect rate limits
- **PR filtering**: Excludes pull requests from issue listings

## New Files
- `src/app/services/issues.service.ts` — IssuesService with caching
- `src/app/components/command-center/issue-board/` — IssueBoardComponent

## Modified Files
- `app.module.ts` — Register IssueBoardComponent
- `command-center.component.ts` — Add 'issues' tab
- `command-center.component.html` — Render issue board

Closes #59