### PR TITLE
feat: all 6 app cards on landing + rename frontend repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "xomware-frontend",
+  "name": "xomware",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "xomware-frontend",
+      "name": "xomware",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.2.14",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xomware-frontend",
+  "name": "xomware",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/command-center/releases/releases.component.ts
+++ b/src/app/components/command-center/releases/releases.component.ts
@@ -5,8 +5,8 @@ import { ReleasesService, RepoReleases, Release, MergedPr } from '../../../servi
 const REPO_COLORS: Record<string, string> = {
   'Float': '#00b4d8',
   'xomfit-ios': '#22c55e',
-  'xomify-frontend': '#a855f7',
-  'xomware-frontend': '#f97316',
+  'xomify': '#a855f7',
+  'xomware': '#f97316',
 };
 
 interface TimelineItem {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -27,6 +27,30 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
 
   apps: AppCard[] = [
     {
+      name: 'xomware',
+      description: 'The mothership. Home of all Xomware apps, agents & infrastructure.',
+      color: '#f97316',
+      url: 'https://xomware.com',
+      monsterState: 'wave',
+      logo: 'assets/img/xomware-icon-transparent-background.png',
+    },
+    {
+      name: 'Float',
+      description: 'Real-time deals for bars & restaurants. Live happy hours near you.',
+      color: '#FFB800',
+      url: 'https://float.xomware.com',
+      monsterState: 'idle',
+      logo: 'assets/img/float-placeholder.svg',
+    },
+    {
+      name: 'xomfit',
+      description: 'Social fitness & lifting tracker. Track lifts, challenge friends.',
+      color: '#34C759',
+      url: 'https://xomfit.xomware.com',
+      monsterState: 'idle',
+      logo: 'assets/img/xomfit-placeholder.svg',
+    },
+    {
       name: 'xomify',
       description: 'Your Spotify stats, wrapped your way. Top songs, artists, genres & more.',
       color: '#9c0abf',

--- a/src/app/services/releases.service.ts
+++ b/src/app/services/releases.service.ts
@@ -29,7 +29,7 @@ export interface RepoReleases {
   recentMergedPrs?: MergedPr[];
 }
 
-const REPOS = ['Float', 'xomfit-ios', 'xomify-frontend', 'xomware-frontend'];
+const REPOS = ['Float', 'xomfit-ios', 'xomify', 'xomware'];
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Changes
- Add all 6 apps to landing page cards: xomware, Float, xomfit, xomify, xomcloud, xomper
- Previously only showed 3 (xomify, xomcloud, xomper)
- Rename `xomware-frontend` → `xomware` in package.json + releases
- Rename `xomify-frontend` → `xomify` in releases service/component
- Build verified ✅