### PR TITLE
feat: all 6 app cards on landing + rename frontend repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xomware-frontend",
+  "name": "xomware",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/command-center/releases/releases.component.ts
+++ b/src/app/components/command-center/releases/releases.component.ts
@@ -5,8 +5,8 @@ import { ReleasesService, RepoReleases, Release, MergedPr } from '../../../servi
 const REPO_COLORS: Record<string, string> = {
   'Float': '#00b4d8',
   'xomfit-ios': '#22c55e',
-  'xomify-frontend': '#a855f7',
-  'xomware-frontend': '#f97316',
+  'xomify': '#a855f7',
+  'xomware': '#f97316',
 };
 
 interface TimelineItem {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -34,6 +34,36 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
 
   apps: AppCard[] = [
     {
+      name: 'Xomware',
+      description: 'The mothership. Home of all Xomware apps, agents & infrastructure.',
+      color: '#f97316',
+      colorRgb: '249, 115, 22',
+      url: 'https://xomware.com',
+      monsterState: 'wave',
+      logo: 'assets/img/xomware-icon-transparent-background.png',
+      tag: 'Platform',
+    },
+    {
+      name: 'Float',
+      description: 'Real-time deals for bars & restaurants. Live happy hours near you.',
+      color: '#FFB800',
+      colorRgb: '255, 184, 0',
+      url: 'https://float.xomware.com',
+      monsterState: 'idle',
+      logo: 'assets/img/float-placeholder.svg',
+      tag: 'iOS · Coming Soon',
+    },
+    {
+      name: 'XomFit',
+      description: 'Social fitness & lifting tracker. Challenge friends, follow AI workout plans.',
+      color: '#34C759',
+      colorRgb: '52, 199, 89',
+      url: 'https://xomfit.xomware.com',
+      monsterState: 'idle',
+      logo: 'assets/img/xomfit-placeholder.svg',
+      tag: 'iOS · Coming Soon',
+    },
+    {
       name: 'Xomify',
       description: 'Your Spotify stats, wrapped your way. Top songs, artists, genres & more.',
       color: '#9c0abf',
@@ -62,26 +92,6 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
       monsterState: 'football',
       logo: 'assets/img/xomper-logo.jpg',
       tag: 'Web App',
-    },
-    {
-      name: 'Meals',
-      description: 'Track what you eat, rate your meals, and build better habits with AI insights.',
-      color: '#ff6b6b',
-      colorRgb: '255, 107, 107',
-      url: 'https://meals.xomware.com',
-      monsterState: 'idle',
-      logo: 'assets/img/xomware-icon-transparent-background.png',
-      tag: 'Web App',
-    },
-    {
-      name: 'XomFit',
-      description: 'Social fitness & lifting tracker. Challenge friends, follow AI workout plans.',
-      color: '#34C759',
-      colorRgb: '52, 199, 89',
-      url: 'https://xomfit.xomware.com',
-      monsterState: 'idle',
-      logo: 'assets/img/xomfit-placeholder.svg',
-      tag: 'iOS · Coming Soon',
     },
   ];
 

--- a/src/app/services/releases.service.ts
+++ b/src/app/services/releases.service.ts
@@ -29,7 +29,7 @@ export interface RepoReleases {
   recentMergedPrs?: MergedPr[];
 }
 
-const REPOS = ['Float', 'xomfit-ios', 'xomify-frontend', 'xomware-frontend'];
+const REPOS = ['Float', 'xomfit-ios', 'xomify', 'xomware'];
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Changes
- Add all 6 apps to landing cards: **Xomware, Float, XomFit, Xomify, XomCloud, Xomper**
- Removed Meals card (not in core 6)
- Added missing Xomware (mothership) and Float cards
- Rename `xomware-frontend` → `xomware` in package.json
- Rename `xomify-frontend` → `xomify` and `xomware-frontend` → `xomware` in releases service/component
- Build verified ✅
- 3-column grid renders 2 rows of 3 perfectly