### PR TITLE
fix: redesign critical bugs - cards, scroll, agent personality

### DIFF
--- a/src/app/components/agent-scene/agent-blob/agent-blob.component.html
+++ b/src/app/components/agent-scene/agent-blob/agent-blob.component.html
@@ -132,6 +132,24 @@
     [style.opacity]="0"
   >{{ agent.displayName }}</svg:text>
 
+  <!-- Hover emoji (random, appears on hover) -->
+  <svg:text
+    class="hover-emoji"
+    x="22"
+    y="-22"
+    text-anchor="middle"
+    font-size="10"
+    opacity="0"
+  >{{ hoverEmoji }}</svg:text>
+
+  <!-- Conversation bubble (appears on click) -->
+  <svg:g class="convo-bubble" opacity="0">
+    <svg:rect x="-30" y="-56" width="60" height="18" rx="6"
+      fill="rgba(10,10,20,0.92)" [attr.stroke]="agent.color" stroke-width="0.8"/>
+    <svg:polygon [attr.points]="'-2,-38 2,-38 0,-34'" fill="rgba(10,10,20,0.92)"/>
+    <svg:text class="convo-text" x="0" y="-44" text-anchor="middle" font-size="5.5" fill="white">{{ convoBubbleText }}</svg:text>
+  </svg:g>
+
   <!-- Status bubble (signature animations) -->
   <svg:g class="status-bubble" opacity="0">
     <svg:rect x="-10" y="-44" width="20" height="12" rx="4"

--- a/src/app/components/agent-scene/agent-blob/agent-blob.component.ts
+++ b/src/app/components/agent-scene/agent-blob/agent-blob.component.ts
@@ -23,12 +23,34 @@ export class AgentBlobComponent implements AfterViewInit, OnDestroy {
 
   @ViewChild('blobGroup', { static: true }) blobGroupRef!: ElementRef<SVGGElement>;
 
+  hoverEmoji = '👋';
+  convoBubbleText = '';
+
   private blinkTimer: any;
   private signatureTimer: any;
   private idleTween: gsap.core.Tween | null = null;
   private prefersReducedMotion = false;
   private isTouchActive = false;
   private touchStartTime = 0;
+  private clickCount = 0;
+
+  private readonly agentEmojis: Record<string, string[]> = {
+    boris: ['📨', '⚡', '🏃', '💬', '📱', '🔥', '😎'],
+    forge: ['🔨', '🛠️', '💻', '🚀', '⚙️', '🏗️', '💪'],
+    winston: ['☕', '✅', '🛡️', '👀', '🔍', '🚦', '💚'],
+    rocco: ['🔬', '🧠', '📊', '🔮', '🎯', '📡', '🤓'],
+    stormy: ['📝', '✍️', '📚', '🗂️', '💭', '🌊', '📖'],
+    debo: ['🏗️', '🔧', '☁️', '🖥️', '⚡', '🔒', '💎'],
+  };
+
+  private readonly agentQuotes: Record<string, string[]> = {
+    boris: ['Dispatching...', 'On it, boss!', 'Message sent! 📨', 'Roger that.', 'Spawning agents...'],
+    forge: ['Building...', 'PR incoming!', 'Code shipped 🚀', 'Tests passing ✅', 'Hammering away...'],
+    winston: ['All green ✓', 'Builds stable', 'Watching pipes...', 'CI clear! ☕', 'Nothing escapes me'],
+    rocco: ['Analyzing...', 'Data says yes', 'Found something!', 'Interesting... 🔬', 'Pattern detected'],
+    stormy: ['Documenting...', 'Memory saved', 'Context logged 📝', 'Writing it down', 'For posterity...'],
+    debo: ['Infra solid 💪', 'Terraform clean', 'Servers humming', 'Zero downtime', 'All nodes green'],
+  };
 
   get el(): SVGGElement {
     return this.blobGroupRef.nativeElement;
@@ -58,6 +80,7 @@ export class AgentBlobComponent implements AfterViewInit, OnDestroy {
   onMouseEnter(): void {
     this.blobHover.emit({ agent: this.agent, entering: true });
     this.playWave();
+    this.showRandomEmoji();
     gsap.to(this.el, {
       scale: 1.15,
       duration: 0.3,
@@ -69,6 +92,8 @@ export class AgentBlobComponent implements AfterViewInit, OnDestroy {
       duration: 0.3,
       ease: 'power2.out',
     });
+    // Color pulse on hover
+    this.playColorPulse();
   }
 
   onMouseLeave(): void {
@@ -83,10 +108,21 @@ export class AgentBlobComponent implements AfterViewInit, OnDestroy {
       opacity: 0,
       duration: 0.2,
     });
+    gsap.to(this.el.querySelector('.hover-emoji'), {
+      opacity: 0,
+      duration: 0.2,
+    });
   }
 
   onClick(): void {
-    this.blobClick.emit(this.agent);
+    this.clickCount++;
+    // Show conversation bubble on first click, open modal on second
+    if (this.clickCount % 2 === 1) {
+      this.showConvoBubble();
+      this.playDanceAnimation();
+    } else {
+      this.blobClick.emit(this.agent);
+    }
   }
 
   onTouchStart(event: TouchEvent): void {
@@ -138,6 +174,83 @@ export class AgentBlobComponent implements AfterViewInit, OnDestroy {
     gsap.to(this.el.querySelector('.agent-label'), {
       opacity: 0,
       duration: 0.2,
+    });
+  }
+
+  // ── Personality animations ──────────────────────────────
+  private showRandomEmoji(): void {
+    const emojis = this.agentEmojis[this.agent.name] || ['👋', '😊', '✨'];
+    this.hoverEmoji = emojis[Math.floor(Math.random() * emojis.length)];
+    const emojiEl = this.el.querySelector('.hover-emoji');
+    if (!emojiEl) return;
+    gsap.fromTo(emojiEl,
+      { opacity: 0, y: 0, scale: 0.5 },
+      {
+        opacity: 1, y: -8, scale: 1.2,
+        duration: 0.4,
+        ease: 'back.out(2)',
+        transformOrigin: 'center center',
+      }
+    );
+  }
+
+  private showConvoBubble(): void {
+    const quotes = this.agentQuotes[this.agent.name] || ['Hey!'];
+    this.convoBubbleText = quotes[Math.floor(Math.random() * quotes.length)];
+    const bubble = this.el.querySelector('.convo-bubble');
+    if (!bubble) return;
+    gsap.fromTo(bubble,
+      { opacity: 0, y: 10, scale: 0.8 },
+      {
+        keyframes: [
+          { opacity: 1, y: 0, scale: 1, duration: 0.3 },
+          { opacity: 1, y: 0, scale: 1, duration: 1.5 },
+          { opacity: 0, y: -10, scale: 0.9, duration: 0.3 },
+        ],
+        transformOrigin: 'center bottom',
+      }
+    );
+  }
+
+  private playDanceAnimation(): void {
+    if (this.prefersReducedMotion) return;
+    // Quick wiggle dance
+    gsap.to(this.el, {
+      keyframes: [
+        { rotation: -8, duration: 0.1 },
+        { rotation: 8, duration: 0.1 },
+        { rotation: -6, duration: 0.1 },
+        { rotation: 6, duration: 0.1 },
+        { rotation: 0, duration: 0.15 },
+      ],
+      transformOrigin: 'center bottom',
+    });
+    // Color flash on body
+    const body = this.el.querySelector('.b-body');
+    if (body) {
+      gsap.to(body, {
+        attr: { fill: '#ffffff' },
+        duration: 0.1,
+        yoyo: true,
+        repeat: 1,
+        onComplete: () => {
+          gsap.set(body, { attr: { fill: this.agent.color } });
+        },
+      });
+    }
+  }
+
+  private playColorPulse(): void {
+    if (this.prefersReducedMotion) return;
+    const halo = this.el.querySelector('.b-halo');
+    if (!halo) return;
+    gsap.to(halo, {
+      opacity: 0.5,
+      attr: { rx: 32, ry: 28 },
+      duration: 0.3,
+      ease: 'power2.out',
+      yoyo: true,
+      repeat: 1,
     });
   }
 

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -7,7 +7,9 @@
   align-items: center;
   background: $bg-dark;
   position: relative;
-  overflow-x: hidden;
+  overflow: visible;
+  // Note: overflow-x: hidden was causing ScrollTrigger lockups
+  // Orbs are handled by .bg-orbs overflow:hidden instead
 }
 
 // ── Ambient Background Orbs ──────────────────────
@@ -17,6 +19,7 @@
   pointer-events: none;
   z-index: 0;
   overflow: hidden;
+  clip: rect(0, auto, auto, 0);
 }
 
 .orb {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -34,16 +34,6 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
 
   apps: AppCard[] = [
     {
-      name: 'Xomware',
-      description: 'The mothership. Home of all Xomware apps, agents & infrastructure.',
-      color: '#f97316',
-      colorRgb: '249, 115, 22',
-      url: 'https://xomware.com',
-      monsterState: 'wave',
-      logo: 'assets/img/xomware-icon-transparent-background.png',
-      tag: 'Platform',
-    },
-    {
       name: 'Float',
       description: 'Real-time deals for bars & restaurants. Live happy hours near you.',
       color: '#FFB800',
@@ -158,7 +148,7 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
         trigger: '.hero',
         start: 'top top',
         end: 'bottom top',
-        scrub: true,
+        scrub: 0.5,
       },
       opacity: 0,
       y: -50,
@@ -205,6 +195,9 @@ export class LandingComponent implements AfterViewInit, OnDestroy {
       duration: 0.6,
       ease: 'power2.out',
     });
+
+    // Refresh ScrollTrigger after all animations are set up
+    ScrollTrigger.refresh();
   }
 
   private checkMobile(): void {


### PR DESCRIPTION
## Fixes

### 1. Remove self-referencing Xomware card
- Removed the xomware.com entry from app cards (showing the site on itself was redundant)

### 2. Fix scroll lockup
- Changed `overflow-x: hidden` to `overflow: visible` on landing container (was conflicting with ScrollTrigger)
- Added `clip` to bg-orbs to contain orb animations without affecting scroll
- Changed scrub from `true` to `0.5` for smoother hero fade
- Added `ScrollTrigger.refresh()` after all animations init

### 3. Agent personality (fun/cool)
- **Random emojis on hover**: Each agent has role-specific emoji sets (Boris: 📨⚡🏃, Forge: 🔨🛠️💻, etc.)
- **Conversation bubbles on click**: First click shows a random quote bubble, second click opens status modal
- **Dance animation**: Wiggle + color flash on click interaction
- **Color pulse**: Halo expands on hover for visual feedback
- **Quotes per agent**: Boris dispatches, Forge ships code, Winston monitors, etc.

### Testing
- Build passes ✅
- Local dev server loads correctly ✅
- All 5 app cards render (Float, XomFit, Xomify, XomCloud, Xomper)
- Agent scene renders with all 6 agents