### PR TITLE
Gate xomware.com landing behind Cognito sign-in

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { LandingComponent } from './components/landing/landing.component';
 import { CommandCenterComponent } from './components/command-center/command-center.component';
 import { AuthGateComponent } from './components/command-center/auth-gate/auth-gate.component';
 import { AuthGuard } from './guards/auth.guard';
+import { cognitoAuthGuard } from './guards/cognito-auth.guard';
 import { SignInComponent } from './components/auth/sign-in/sign-in.component';
 import { SignUpComponent } from './components/auth/sign-up/sign-up.component';
 import { VerifyComponent } from './components/auth/verify/verify.component';
@@ -12,7 +13,7 @@ import { CallbackComponent } from './components/auth/callback/callback.component
 import { ProfileComponent } from './components/auth/profile/profile.component';
 
 const routes: Routes = [
-  { path: '', component: LandingComponent },
+  { path: '', component: LandingComponent, canActivate: [cognitoAuthGuard] },
   { path: 'auth/sign-in', component: SignInComponent },
   { path: 'auth/sign-up', component: SignUpComponent },
   { path: 'auth/verify', component: VerifyComponent },

--- a/src/app/components/auth/sign-in/sign-in.component.ts
+++ b/src/app/components/auth/sign-in/sign-in.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CognitoService } from '../../../services/cognito.service';
@@ -9,10 +9,12 @@ import { AnalyticsService } from '../../../services/analytics.service';
   templateUrl: './sign-in.component.html',
   styleUrls: ['./sign-in.component.scss'],
 })
-export class SignInComponent {
+export class SignInComponent implements OnInit {
   readonly form: FormGroup;
   loading = false;
   errorMessage = '';
+  /** Path to bounce to after a successful sign-in. Set from `?next=` on init. */
+  private nextPath = '/';
 
   constructor(
     private fb: FormBuilder,
@@ -25,6 +27,17 @@ export class SignInComponent {
       email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(8)]],
     });
+  }
+
+  ngOnInit(): void {
+    const raw = this.route.snapshot.queryParamMap.get('next');
+    if (raw) {
+      const decoded = decodeURIComponent(raw);
+      // Only honor app-internal paths to avoid open-redirect via `?next=https://evil.com`.
+      if (decoded.startsWith('/') && !decoded.startsWith('//')) {
+        this.nextPath = decoded;
+      }
+    }
   }
 
   fieldInvalid(name: 'email' | 'password'): boolean {
@@ -44,13 +57,15 @@ export class SignInComponent {
     this.cognito.signIn(email, password).subscribe({
       next: () => {
         this.analytics.track('login', { method: 'cognito' });
-        const redirect = this.route.snapshot.queryParamMap.get('redirect') ?? '/';
-        this.router.navigateByUrl(redirect);
+        this.router.navigateByUrl(this.nextPath);
       },
       error: (err: Error) => {
         this.loading = false;
         if (err.message === 'CONFIRM_SIGN_UP') {
-          this.router.navigate(['/auth/verify'], { queryParams: { email } });
+          // Forward `next` so post-verify-and-sign-in lands on the original target.
+          this.router.navigate(['/auth/verify'], {
+            queryParams: { email, next: this.nextPath },
+          });
           return;
         }
         this.errorMessage = this.friendlyError(err);

--- a/src/app/components/auth/verify/verify.component.ts
+++ b/src/app/components/auth/verify/verify.component.ts
@@ -16,6 +16,8 @@ export class VerifyComponent implements OnInit {
   errorMessage = '';
   infoMessage = '';
   email = '';
+  /** Forwarded to sign-in after verify so the auth-gate `next` survives sign-up→verify→sign-in. */
+  private nextPath: string | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -31,6 +33,10 @@ export class VerifyComponent implements OnInit {
 
   ngOnInit(): void {
     this.email = this.route.snapshot.queryParamMap.get('email') ?? '';
+    const raw = this.route.snapshot.queryParamMap.get('next');
+    if (raw && raw.startsWith('/') && !raw.startsWith('//')) {
+      this.nextPath = raw;
+    }
   }
 
   fieldInvalid(name: 'code'): boolean {
@@ -57,7 +63,9 @@ export class VerifyComponent implements OnInit {
         this.loading = false;
         if (confirmed) {
           this.analytics.track('verify_email');
-          this.router.navigate(['/auth/sign-in'], { queryParams: { email: this.email } });
+          const queryParams: Record<string, string> = { email: this.email };
+          if (this.nextPath) queryParams['next'] = this.nextPath;
+          this.router.navigate(['/auth/sign-in'], { queryParams });
         } else {
           this.errorMessage = 'Verification did not complete. Try the code again.';
         }

--- a/src/app/guards/cognito-auth.guard.ts
+++ b/src/app/guards/cognito-auth.guard.ts
@@ -1,0 +1,27 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+import { CognitoService } from '../services/cognito.service';
+
+/**
+ * Gate routes behind a valid Cognito session.
+ *
+ * Waits for `CognitoService.isReady$` so the initial paint never flashes
+ * protected content (e.g. the landing app cards) before the redirect fires.
+ * Anonymous visitors are bounced to `/auth/sign-in?next=<requested-url>`.
+ */
+export const cognitoAuthGuard: CanActivateFn = async (_route, state) => {
+  const cognito = inject(CognitoService);
+  const router = inject(Router);
+
+  // Wait for the initial session check to settle — don't gate on stale state.
+  await firstValueFrom(cognito.isReady$.pipe(filter((ready) => ready), take(1)));
+
+  if (cognito.isAuthenticated()) {
+    return true;
+  }
+
+  const next = encodeURIComponent(state.url);
+  return router.parseUrl(`/auth/sign-in?next=${next}`);
+};

--- a/src/app/services/cognito.service.ts
+++ b/src/app/services/cognito.service.ts
@@ -30,14 +30,21 @@ export interface XomUser {
 @Injectable({ providedIn: 'root' })
 export class CognitoService implements OnDestroy {
   private readonly userSubject = new BehaviorSubject<XomUser | null>(null);
+  private readonly readySubject = new BehaviorSubject<boolean>(false);
   private hubSub?: () => void;
 
   readonly user$: Observable<XomUser | null> = this.userSubject.asObservable();
   readonly isAuthenticated$: Observable<boolean> = this.user$.pipe(map((u) => !!u));
+  /**
+   * Emits `true` once the initial session check has settled (signed-in or not).
+   * Route guards subscribe to this so the gate doesn't fire on stale `null` state
+   * during the first paint and flash protected content before redirecting.
+   */
+  readonly isReady$: Observable<boolean> = this.readySubject.asObservable();
 
   constructor() {
     // Bootstrap current session on app start
-    this.refreshUser();
+    this.bootstrap();
 
     // React to Amplify auth events (sign-in, sign-out, OAuth redirect, token refresh)
     this.hubSub = Hub.listen('auth', ({ payload }) => {
@@ -60,6 +67,21 @@ export class CognitoService implements OnDestroy {
 
   get currentUser(): XomUser | null {
     return this.userSubject.value;
+  }
+
+  /** Synchronous check used by route guards after `isReady$` resolves. */
+  isAuthenticated(): boolean {
+    return this.userSubject.value !== null;
+  }
+
+  private async bootstrap(): Promise<void> {
+    try {
+      await this.refreshUser();
+    } catch {
+      // No session is fine — userSubject is already null.
+    } finally {
+      this.readySubject.next(true);
+    }
   }
 
   signIn(email: string, password: string): Observable<XomUser> {


### PR DESCRIPTION
## Summary

- Adds a `cognitoAuthGuard` (functional `CanActivateFn`) on the `/` route. Anonymous visitors are redirected to `/auth/sign-in?next=<requested-path>`.
- `CognitoService` now exposes `isReady$` and a synchronous `isAuthenticated()`. The guard awaits `isReady$` before deciding so the landing app cards never flash before the redirect resolves on a cold load.
- Sign-in reads `?next=` on init and bounces there post-success. Verify forwards `?next=` to sign-in, so the sign-up → verify → sign-in chain lands users on their original target. Only app-internal paths (`/...`) are honored to block open-redirect via `?next=https://evil.com`.

## Behavior changes

- **Public discovery is GONE.** Anonymous visitors can no longer see the app directory on xomware.com — they hit sign-in first. This is intentional per Dom's request.
- `/auth/*` routes stay public so sign-up, verify, forgot-password, and the OAuth callback continue to work when signed out.
- `/command` still uses the legacy passphrase `AuthGuard` — untouched.

## Files changed

- `src/app/guards/cognito-auth.guard.ts` (new) — functional guard wired to `CognitoService`
- `src/app/services/cognito.service.ts` — adds `isReady$`, `isAuthenticated()`, `bootstrap()` so initial session check resolves before guard fires
- `src/app/app-routing.module.ts` — applies guard to `/` only
- `src/app/components/auth/sign-in/sign-in.component.ts` — reads `?next=`, redirects there on success, forwards `next` to verify on `CONFIRM_SIGN_UP`
- `src/app/components/auth/verify/verify.component.ts` — forwards `?next=` through to sign-in after verify

## Test plan

- [ ] Sign out, hit `/` → redirects to `/auth/sign-in?next=%2F`, no flash of landing app cards
- [ ] Sign in → lands on `/`
- [ ] Hit `/auth/sign-in` directly while signed out → page renders (guard does not gate `/auth/*`)
- [ ] Sign up new user → verify code → arrives at sign-in → sign in → lands on `/`
- [ ] Already signed in, hit `/` → renders landing immediately
- [ ] `?next=https://evil.com` is ignored; defaults to `/`
- [ ] `/command/login` and `/command` still gated by legacy `AuthGuard` only

## CI

This repo's deploy workflow only runs on push-to-master, so PR CI is not expected to fire. `npx ng build --configuration production` passes locally (743.69 kB initial, no errors).