### PR TITLE
Phase 3 (xomware-frontend): profile page + edit + avatars

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -40,6 +40,8 @@ jobs:
             echo "COGNITO_CLIENT_ID=$(aws ssm get-parameter --name /xomware/shared/cognito/clients/xomware-com-id --query Parameter.Value --output text)"
             echo "COGNITO_DOMAIN=$(aws ssm get-parameter --name /xomware/shared/cognito/hosted-ui-domain --query Parameter.Value --output text)"
             echo "FILE_EDITOR_API_URL=$(aws ssm get-parameter --name /xomware/shared/file-editor-api/url --query Parameter.Value --output text)"
+            echo "USERS_API_URL=$(aws ssm get-parameter --name /xomware/shared/users-api/url --query Parameter.Value --output text)"
+            echo "AVATARS_CDN_URL=$(aws ssm get-parameter --name /xomware/shared/avatars/cdn-url --query Parameter.Value --output text)"
           } >> "$GITHUB_ENV"
 
       - name: Inject environment variables into Angular
@@ -53,13 +55,17 @@ jobs:
           sed -i "s|cognitoClientId: ''|cognitoClientId: '${COGNITO_CLIENT_ID}'|g" src/environments/environment.ts
           sed -i "s|cognitoDomain: 'xomware-auth.auth.us-east-1.amazoncognito.com'|cognitoDomain: '${COGNITO_DOMAIN}'|g" src/environments/environment.ts
           sed -i "s|ga4MeasurementId: ''|ga4MeasurementId: '${GA4_MEASUREMENT_ID}'|g" src/environments/environment.ts
-          # File-editor API URL comes from /xomware/shared/file-editor-api/url
-          # (Command Center backend, migrated from api.xomware.com to
-          # editor-api.xomware.com). Default in environment.ts is the new
-          # domain so the build still works if SSM is empty during a
-          # transitional deploy.
+          # File-editor + users-api + avatars CDN URLs come from SSM (set above).
+          # Defaults in environment.ts already point at the prod hosts so a build
+          # works if SSM is empty during a transitional deploy.
           if [ -n "${FILE_EDITOR_API_URL}" ]; then
             sed -i "s|apiBaseUrl: 'https://editor-api.xomware.com'|apiBaseUrl: '${FILE_EDITOR_API_URL}'|g" src/environments/environment.ts
+          fi
+          if [ -n "${USERS_API_URL}" ]; then
+            sed -i "s|usersApiUrl: 'https://api.xomware.com'|usersApiUrl: '${USERS_API_URL}'|g" src/environments/environment.ts
+          fi
+          if [ -n "${AVATARS_CDN_URL}" ]; then
+            sed -i "s|avatarsCdnUrl: ''|avatarsCdnUrl: '${AVATARS_CDN_URL}'|g" src/environments/environment.ts
           fi
 
       - name: Build

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,8 +2,10 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
+import { jwtInterceptor } from './interceptors/jwt.interceptor';
 import { AppComponent } from './app.component';
 import { LandingComponent } from './components/landing/landing.component';
 import { MonsterComponent } from './components/monster/monster.component';
@@ -39,7 +41,7 @@ import { ProfileComponent } from './components/auth/profile/profile.component';
     ReactiveFormsModule,
     AppRoutingModule,
   ],
-  providers: [],
+  providers: [provideHttpClient(withInterceptors([jwtInterceptor]))],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/components/auth/profile/profile.component.html
+++ b/src/app/components/auth/profile/profile.component.html
@@ -1,34 +1,248 @@
 <div class="auth-shell">
-  <div class="auth-card">
+  <div class="auth-card profile-card-wide">
     <a routerLink="/" class="auth-brand" aria-label="Xomware home">
       <img src="assets/img/xomware-icon-transparent-background.png" alt="" />
       <span>XOMWARE</span>
     </a>
 
-    <ng-container *ngIf="user$ | async as user; else signedOut">
-      <h1 class="auth-title">&#64;{{ user.preferredUsername || user.username }}</h1>
-      <p class="auth-subtitle">{{ user.email }}</p>
+    <ng-container *ngIf="profile$ | async as profile; else loadingOrSignedOut">
+      <!-- Header: avatar + handle + name -->
+      <div class="profile-hero">
+        <div
+          class="profile-avatar-large"
+          [class.has-image]="profile.avatarUrl || pendingAvatarUrl"
+          [attr.aria-label]="'Avatar for ' + fallbackDisplayName(profile)"
+        >
+          <img
+            *ngIf="profile.avatarUrl || pendingAvatarUrl"
+            [src]="pendingAvatarUrl || profile.avatarUrl"
+            [alt]="fallbackDisplayName(profile) + ' avatar'"
+          />
+          <span
+            *ngIf="!profile.avatarUrl && !pendingAvatarUrl"
+            class="profile-avatar-initial"
+            aria-hidden="true"
+          >{{ avatarInitial(profile) }}</span>
+        </div>
 
-      <div class="profile-card">
-        <p class="profile-blurb">
-          Your Xomware profile lives here. Avatar, username editing, and linked
-          apps land in Phase 3.
-        </p>
+        <h1 class="profile-handle">&#64;{{ profile.preferredUsername }}</h1>
+        <p class="profile-display-name">{{ fallbackDisplayName(profile) }}</p>
+        <p class="profile-email" *ngIf="profile.email">{{ profile.email }}</p>
+
+        <span
+          class="profile-visibility-badge"
+          [class.private]="profile.profileVisibility === 'private'"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="badge-icon"
+            aria-hidden="true"
+          >
+            <path
+              *ngIf="profile.profileVisibility === 'public'"
+              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"
+              fill="currentColor"
+            />
+            <path
+              *ngIf="profile.profileVisibility === 'private'"
+              d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1v2z"
+              fill="currentColor"
+            />
+          </svg>
+          {{ profile.profileVisibility === 'public' ? 'Public profile' : 'Private profile' }}
+        </span>
       </div>
 
-      <button type="button" class="auth-btn-ghost" (click)="signOut()">
-        Sign out
-      </button>
+      <!-- Stats placeholders (v1) -->
+      <div class="profile-stats" role="list">
+        <div class="profile-stat" role="listitem">
+          <span class="stat-value">0</span>
+          <span class="stat-label">Apps</span>
+        </div>
+        <div class="profile-stat" role="listitem">
+          <span class="stat-value">0</span>
+          <span class="stat-label">Followers</span>
+        </div>
+        <div class="profile-stat" role="listitem">
+          <span class="stat-value">0</span>
+          <span class="stat-label">Following</span>
+        </div>
+        <div class="profile-stat" role="listitem">
+          <span class="stat-value">0</span>
+          <span class="stat-label">Posts</span>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="profile-actions">
+        <button type="button" class="auth-btn" (click)="openEdit()">
+          Edit profile
+        </button>
+        <button type="button" class="auth-btn-ghost" (click)="signOut()">
+          Sign out
+        </button>
+      </div>
     </ng-container>
 
-    <ng-template #signedOut>
-      <h1 class="auth-title">You're signed out</h1>
-      <p class="auth-subtitle">Sign in to view your profile.</p>
-      <a routerLink="/auth/sign-in" class="auth-btn" style="text-decoration: none;">
-        Sign in
-      </a>
+    <ng-template #loadingOrSignedOut>
+      <ng-container *ngIf="cognito.isAuthenticated(); else signedOut">
+        <h1 class="auth-title">Loading your profile…</h1>
+        <p class="auth-subtitle">One sec.</p>
+      </ng-container>
+      <ng-template #signedOut>
+        <h1 class="auth-title">You're signed out</h1>
+        <p class="auth-subtitle">Sign in to view your profile.</p>
+        <a
+          routerLink="/auth/sign-in"
+          class="auth-btn"
+          style="text-decoration: none;"
+        >Sign in</a>
+      </ng-template>
     </ng-template>
 
     <a routerLink="/" class="auth-back">&larr; Back to xomware.com</a>
+  </div>
+</div>
+
+<!-- Edit profile modal -->
+<div
+  class="edit-modal-backdrop"
+  *ngIf="editOpen"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="edit-profile-title"
+  (click)="closeEdit()"
+>
+  <div class="edit-modal" (click)="$event.stopPropagation()">
+    <header class="edit-modal-header">
+      <h2 id="edit-profile-title" class="edit-modal-title">Edit profile</h2>
+      <button
+        type="button"
+        class="edit-modal-close"
+        aria-label="Close"
+        (click)="closeEdit()"
+      >&times;</button>
+    </header>
+
+    <form
+      [formGroup]="editForm"
+      (ngSubmit)="onSubmit()"
+      class="auth-form edit-modal-form"
+      novalidate
+    >
+      <!-- Avatar upload -->
+      <div class="auth-field">
+        <span class="auth-label">Avatar</span>
+        <div class="avatar-upload-row">
+          <ng-container *ngIf="profile$ | async as p">
+            <div
+              class="profile-avatar-medium"
+              [class.has-image]="pendingAvatarUrl || p.avatarUrl"
+            >
+              <img
+                *ngIf="pendingAvatarUrl || p.avatarUrl"
+                [src]="pendingAvatarUrl || p.avatarUrl"
+                alt=""
+              />
+              <span
+                *ngIf="!pendingAvatarUrl && !p.avatarUrl"
+                class="profile-avatar-initial"
+                aria-hidden="true"
+              >{{ avatarInitial(p) }}</span>
+            </div>
+          </ng-container>
+
+          <label class="auth-btn-ghost avatar-upload-button">
+            <span *ngIf="!uploadingAvatar">
+              {{ pendingAvatarUrl ? 'Choose a different image' : 'Upload new avatar' }}
+            </span>
+            <span *ngIf="uploadingAvatar" class="spinner" aria-label="Uploading"></span>
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              (change)="onAvatarFileSelected($event)"
+              [disabled]="uploadingAvatar || saving"
+              hidden
+            />
+          </label>
+        </div>
+        <span class="auth-hint">PNG, JPG, or WebP. Saved when you press Save.</span>
+      </div>
+
+      <!-- Display name -->
+      <div class="auth-field">
+        <label for="edit-display-name" class="auth-label">Display name</label>
+        <input
+          id="edit-display-name"
+          type="text"
+          formControlName="displayName"
+          class="auth-input"
+          [class.invalid]="fieldInvalid('displayName')"
+          maxlength="50"
+          placeholder="Your full name"
+          autocomplete="name"
+          [attr.aria-invalid]="fieldInvalid('displayName') || null"
+          [attr.aria-describedby]="fieldInvalid('displayName') ? 'edit-display-name-error' : null"
+        />
+        <span
+          *ngIf="fieldInvalid('displayName')"
+          id="edit-display-name-error"
+          class="auth-error-field"
+        >
+          Display name must be 1–50 characters.
+        </span>
+      </div>
+
+      <!-- Visibility -->
+      <fieldset class="auth-field visibility-field">
+        <legend class="auth-label">Profile visibility</legend>
+        <label class="visibility-option">
+          <input
+            type="radio"
+            formControlName="profileVisibility"
+            value="public"
+          />
+          <span class="visibility-option-label">
+            <strong>Public</strong>
+            <span class="visibility-option-hint">
+              Anyone can find you by your &#64;handle.
+            </span>
+          </span>
+        </label>
+        <label class="visibility-option">
+          <input
+            type="radio"
+            formControlName="profileVisibility"
+            value="private"
+          />
+          <span class="visibility-option-label">
+            <strong>Private</strong>
+            <span class="visibility-option-hint">
+              Only people you approve can see your profile.
+            </span>
+          </span>
+        </label>
+      </fieldset>
+
+      <p *ngIf="errorMessage" class="auth-error" role="alert">{{ errorMessage }}</p>
+
+      <div class="edit-modal-actions">
+        <button
+          type="button"
+          class="auth-btn-ghost"
+          (click)="closeEdit()"
+          [disabled]="saving || uploadingAvatar"
+        >Cancel</button>
+        <button
+          type="submit"
+          class="auth-btn"
+          [disabled]="saving || uploadingAvatar"
+        >
+          <span *ngIf="!saving">Save</span>
+          <span *ngIf="saving" class="spinner" aria-label="Saving"></span>
+        </button>
+      </div>
+    </form>
   </div>
 </div>

--- a/src/app/components/auth/profile/profile.component.scss
+++ b/src/app/components/auth/profile/profile.component.scss
@@ -1,17 +1,335 @@
 @import '../_shared/auth-shell';
 
-.profile-card {
-  margin-top: $spacing-lg;
+// ── Wider card for the profile (vs. the narrow auth forms) ──────────────────
+.profile-card-wide {
+  max-width: 560px;
+}
+
+// ── Hero (avatar + handle + name + email + visibility badge) ────────────────
+.profile-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: $spacing-xs;
   margin-bottom: $spacing-xl;
-  padding: $spacing-md $spacing-lg;
+}
+
+.profile-avatar-large {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, $meals-coral, color-mix(in srgb, $meals-coral 70%, $brand-cyan-dark));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 2px solid $glass-border;
+  box-shadow: $shadow-glow-cyan;
+  margin-bottom: $spacing-md;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &.has-image {
+    background: $bg-card;
+  }
+}
+
+.profile-avatar-initial {
+  font-size: 3rem;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
+  line-height: 1;
+  letter-spacing: 0.02em;
+}
+
+.profile-handle {
+  font-size: 1.5rem;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
+  margin: 0;
+}
+
+.profile-display-name {
+  font-size: 1rem;
+  color: $text-secondary;
+  margin: 0;
+}
+
+.profile-email {
+  font-size: 0.85rem;
+  color: $text-muted;
+  margin: $spacing-xs 0 0;
+  word-break: break-all;
+}
+
+.profile-visibility-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: $spacing-sm;
+  padding: 4px 12px;
+  background: $brand-cyan-subtle;
+  border: 1px solid rgba(0, 180, 216, 0.25);
+  border-radius: $radius-pill;
+  color: $brand-cyan-light;
+  font-size: 0.75rem;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+
+  &.private {
+    background: rgba(255, 107, 107, 0.08);
+    border-color: rgba(255, 107, 107, 0.25);
+    color: lighten($meals-coral, 10%);
+  }
+
+  .badge-icon {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+// ── Stats grid (placeholders for v1) ────────────────────────────────────────
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: $spacing-sm;
+  padding: $spacing-md;
+  margin-bottom: $spacing-xl;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid $glass-border;
   border-radius: $radius-md;
+
+  @media (max-width: $breakpoint-sm) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-.profile-blurb {
+.profile-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.25rem;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: $text-muted;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+// ── Action row ──────────────────────────────────────────────────────────────
+.profile-actions {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+
+  .auth-btn,
+  .auth-btn-ghost {
+    width: 100%;
+  }
+}
+
+// ── Edit profile modal ──────────────────────────────────────────────────────
+.edit-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 20, 0.75);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-md;
+  z-index: 1000;
+  animation: authFadeIn 0.2s ease-out;
+}
+
+.edit-modal {
+  width: 100%;
+  max-width: 480px;
+  max-height: calc(100vh - #{$spacing-xl});
+  overflow-y: auto;
+  padding: $spacing-xl;
+  background: $card-gradient;
+  border: 1px solid $glass-border;
+  border-radius: $radius-xl;
+  box-shadow: $shadow-lg, $shadow-glow-cyan;
+}
+
+.edit-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: $spacing-lg;
+}
+
+.edit-modal-title {
+  font-size: 1.25rem;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
   margin: 0;
-  font-size: 0.9rem;
-  line-height: 1.5;
+}
+
+.edit-modal-close {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: $radius-sm;
   color: $text-secondary;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all $transition-base;
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan-light;
+    outline-offset: 2px;
+  }
+}
+
+.edit-modal-form {
+  gap: $spacing-lg;
+}
+
+.edit-modal-actions {
+  display: flex;
+  gap: $spacing-sm;
+  margin-top: $spacing-md;
+
+  .auth-btn,
+  .auth-btn-ghost {
+    flex: 1;
+  }
+}
+
+// ── Avatar upload row inside the modal ──────────────────────────────────────
+.avatar-upload-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+}
+
+.profile-avatar-medium {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, $meals-coral, color-mix(in srgb, $meals-coral 70%, $brand-cyan-dark));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 2px solid $glass-border;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .profile-avatar-initial {
+    font-size: 1.75rem;
+  }
+
+  &.has-image {
+    background: $bg-card;
+  }
+}
+
+.avatar-upload-button {
+  flex: 1;
+  cursor: pointer;
+  margin: 0;
+
+  &:has(input:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// ── Visibility radios ───────────────────────────────────────────────────────
+.visibility-field {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.visibility-option {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid $glass-border;
+  border-radius: $radius-md;
+  cursor: pointer;
+  transition: all $transition-base;
+
+  & + & {
+    margin-top: $spacing-xs;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.15);
+  }
+
+  &:has(input:checked) {
+    background: $brand-cyan-subtle;
+    border-color: rgba(0, 180, 216, 0.4);
+  }
+
+  &:has(input:focus-visible) {
+    outline: 2px solid $brand-cyan-light;
+    outline-offset: 2px;
+  }
+
+  input[type='radio'] {
+    margin-top: 2px;
+    accent-color: $brand-cyan;
+    cursor: pointer;
+  }
+}
+
+.visibility-option-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: $text-primary;
+  font-size: 0.9rem;
+
+  strong {
+    font-weight: $font-weight-semibold;
+  }
+}
+
+.visibility-option-hint {
+  color: $text-secondary;
+  font-size: 0.8rem;
 }

--- a/src/app/components/auth/profile/profile.component.ts
+++ b/src/app/components/auth/profile/profile.component.ts
@@ -1,22 +1,174 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
-import { CognitoService, XomUser } from '../../../services/cognito.service';
+import { Observable, Subscription } from 'rxjs';
+import { CognitoService } from '../../../services/cognito.service';
+import { ProfileService } from '../../../services/profile.service';
+import { UsersService } from '../../../services/users.service';
+import {
+  ProfileVisibility,
+  UserProfile,
+} from '../../../models/user.model';
 
-/**
- * Phase 2 placeholder. Real profile editing (avatar, username changes, linked
- * apps) lands in Phase 3.
- */
+const ALLOWED_AVATAR_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+const MAX_DISPLAY_NAME = 50;
+
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss'],
 })
-export class ProfileComponent {
-  readonly user$: Observable<XomUser | null>;
+export class ProfileComponent implements OnInit, OnDestroy {
+  readonly profile$: Observable<UserProfile | null>;
+  readonly editForm: FormGroup;
 
-  constructor(private cognito: CognitoService, private router: Router) {
-    this.user$ = this.cognito.user$;
+  editOpen = false;
+  saving = false;
+  uploadingAvatar = false;
+  errorMessage = '';
+
+  /** Live-preview URL while a freshly-uploaded avatar isn't yet persisted via `edit()`. */
+  pendingAvatarUrl: string | null = null;
+
+  private profileSub?: Subscription;
+  private currentProfile: UserProfile | null = null;
+
+  constructor(
+    public cognito: CognitoService,
+    private profileService: ProfileService,
+    private users: UsersService,
+    private fb: FormBuilder,
+    private router: Router,
+  ) {
+    this.profile$ = this.profileService.profile$;
+    this.editForm = this.fb.group({
+      displayName: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(1),
+          Validators.maxLength(MAX_DISPLAY_NAME),
+        ],
+      ],
+      profileVisibility: ['public' as ProfileVisibility, Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.profileSub = this.profileService.profile$.subscribe(
+      (p) => (this.currentProfile = p),
+    );
+    // Refresh on enter — covers the case where the user landed here mid-session
+    // before the BehaviorSubject was primed.
+    if (!this.profileService.currentProfile) {
+      this.profileService.refresh();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.profileSub?.unsubscribe();
+  }
+
+  /** Display name fallback chain when the API hasn't loaded yet. */
+  fallbackDisplayName(profile: UserProfile | null): string {
+    if (profile?.displayName) return profile.displayName;
+    if (profile?.preferredUsername) return profile.preferredUsername;
+    return this.cognito.currentUser?.preferredUsername ?? 'You';
+  }
+
+  /** First letter for the coral avatar fallback bubble. */
+  avatarInitial(profile: UserProfile | null): string {
+    const source =
+      profile?.displayName ??
+      profile?.preferredUsername ??
+      this.cognito.currentUser?.preferredUsername ??
+      '?';
+    return source.trim().charAt(0).toUpperCase() || '?';
+  }
+
+  openEdit(): void {
+    if (!this.currentProfile) return;
+    this.errorMessage = '';
+    this.pendingAvatarUrl = null;
+    this.editForm.reset({
+      displayName: this.currentProfile.displayName ?? '',
+      profileVisibility: this.currentProfile.profileVisibility ?? 'public',
+    });
+    this.editOpen = true;
+  }
+
+  closeEdit(): void {
+    if (this.saving || this.uploadingAvatar) return;
+    this.editOpen = false;
+    this.pendingAvatarUrl = null;
+    this.errorMessage = '';
+  }
+
+  fieldInvalid(name: 'displayName'): boolean {
+    const ctrl = this.editForm.get(name);
+    return !!ctrl && ctrl.invalid && (ctrl.dirty || ctrl.touched);
+  }
+
+  onAvatarFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+      this.errorMessage = 'Avatar must be a PNG, JPG, or WebP image.';
+      input.value = '';
+      return;
+    }
+
+    this.errorMessage = '';
+    this.uploadingAvatar = true;
+    this.users.uploadAvatar(file).subscribe({
+      next: (finalUrl) => {
+        this.pendingAvatarUrl = finalUrl;
+        this.uploadingAvatar = false;
+        input.value = '';
+      },
+      error: () => {
+        this.uploadingAvatar = false;
+        this.errorMessage = 'Avatar upload failed. Please try again.';
+        input.value = '';
+      },
+    });
+  }
+
+  onSubmit(): void {
+    if (this.editForm.invalid || this.saving) {
+      this.editForm.markAllAsTouched();
+      return;
+    }
+    this.saving = true;
+    this.errorMessage = '';
+
+    const { displayName, profileVisibility } = this.editForm.value as {
+      displayName: string;
+      profileVisibility: ProfileVisibility;
+    };
+
+    const payload: Record<string, unknown> = {
+      displayName: displayName.trim(),
+      profileVisibility,
+    };
+    if (this.pendingAvatarUrl) {
+      payload['avatarUrl'] = this.pendingAvatarUrl;
+    }
+
+    this.users.edit(payload).subscribe({
+      next: (updated) => {
+        this.profileService.setProfile(updated);
+        this.saving = false;
+        this.editOpen = false;
+        this.pendingAvatarUrl = null;
+      },
+      error: () => {
+        this.saving = false;
+        this.errorMessage = 'Could not save changes. Please try again.';
+      },
+    });
   }
 
   signOut(): void {

--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -61,8 +61,19 @@
             (click)="toggleUserMenu($event)"
             [attr.aria-expanded]="userMenuOpen"
             aria-haspopup="menu"
+            [attr.aria-label]="'Account menu for @' + userHandle"
           >
-            <span class="user-menu-handle">&#64;{{ user.preferredUsername || user.username }}</span>
+            <span class="user-menu-avatar" [class.has-image]="profile?.avatarUrl">
+              <img
+                *ngIf="profile?.avatarUrl as src"
+                [src]="src"
+                [alt]="''"
+              />
+              <span *ngIf="!profile?.avatarUrl" class="user-menu-avatar-initial" aria-hidden="true">
+                {{ userInitial }}
+              </span>
+            </span>
+            <span class="user-menu-handle">&#64;{{ userHandle }}</span>
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="report-menu-caret" [class.open]="userMenuOpen" aria-hidden="true">
               <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" fill="currentColor"/>
             </svg>

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -1129,10 +1129,13 @@
 .user-menu-trigger {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  padding: 6px 14px;
+  padding: 4px 12px 4px 4px;
   border-radius: $radius-pill;
   cursor: pointer;
   font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
   transition: all $transition-fast;
 
   &:hover {
@@ -1144,6 +1147,36 @@
     outline: 2px solid $brand-cyan-light;
     outline-offset: 2px;
   }
+}
+
+.user-menu-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, $meals-coral, color-mix(in srgb, $meals-coral 70%, $brand-cyan-dark));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+  color: $text-primary;
+  font-size: 0.8rem;
+  font-weight: $font-weight-bold;
+
+  &.has-image {
+    background: $bg-card;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.user-menu-avatar-initial {
+  line-height: 1;
 }
 
 .user-menu-handle {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -4,6 +4,8 @@ import { Subscription } from 'rxjs';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { CognitoService, XomUser } from '../../services/cognito.service';
+import { ProfileService } from '../../services/profile.service';
+import { UserProfile } from '../../models/user.model';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -35,16 +37,43 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
   reportMenuOpen = false;
   userMenuOpen = false;
   user: XomUser | null = null;
+  profile: UserProfile | null = null;
   private userSub?: Subscription;
+  private profileSub?: Subscription;
 
   constructor(
     private host: ElementRef<HTMLElement>,
     private cognito: CognitoService,
+    private profileService: ProfileService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
     this.userSub = this.cognito.user$.subscribe((u) => (this.user = u));
+    this.profileSub = this.profileService.profile$.subscribe(
+      (p) => (this.profile = p),
+    );
+  }
+
+  /** First letter of the displayName/handle for the coral fallback bubble. */
+  get userInitial(): string {
+    const source =
+      this.profile?.displayName ??
+      this.profile?.preferredUsername ??
+      this.user?.preferredUsername ??
+      this.user?.username ??
+      '?';
+    return source.trim().charAt(0).toUpperCase() || '?';
+  }
+
+  /** Display name + handle for the user menu trigger label. */
+  get userHandle(): string {
+    return (
+      this.profile?.preferredUsername ??
+      this.user?.preferredUsername ??
+      this.user?.username ??
+      ''
+    );
   }
 
   toggleUserMenu(event: Event): void {
@@ -243,6 +272,7 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
   ngOnDestroy(): void {
     ScrollTrigger.getAll().forEach(t => t.kill());
     this.userSub?.unsubscribe();
+    this.profileSub?.unsubscribe();
   }
 
   private initScrollAnimations(): void {

--- a/src/app/interceptors/jwt.interceptor.ts
+++ b/src/app/interceptors/jwt.interceptor.ts
@@ -1,0 +1,32 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { from, switchMap } from 'rxjs';
+import { CognitoService } from '../services/cognito.service';
+import { environment } from '../../environments/environment';
+
+/**
+ * Attaches the Cognito ID token as a Bearer header on calls to the shared
+ * Xomware API (`apiBaseUrl`). Skips presigned S3 PUTs (those carry their own
+ * signature in the URL — adding Authorization breaks the signature check).
+ */
+export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
+  const isApiCall =
+    req.url.startsWith(environment.apiBaseUrl) ||
+    req.url.startsWith(environment.usersApiUrl);
+  if (!isApiCall) {
+    return next(req);
+  }
+
+  const cognito = inject(CognitoService);
+  return from(cognito.getJwt()).pipe(
+    switchMap((token) => {
+      if (!token) {
+        return next(req);
+      }
+      const authed = req.clone({
+        setHeaders: { Authorization: `Bearer ${token}` },
+      });
+      return next(authed);
+    }),
+  );
+};

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared user types for the xomware-users service (`api.xomware.com/users/*`).
+ *
+ * Mirrors the API contract documented in the auth Phase 3 plan. Same shapes
+ * are consumed by other Xomware frontends (xomappetit, xomify, etc.) so keep
+ * this file in lock-step with the backend.
+ */
+
+export type ProfileVisibility = 'public' | 'private';
+
+/**
+ * Full profile returned by `POST /users/me` and `POST /users/edit`. Owned by
+ * the signed-in user — includes private fields (email, raw `userId`).
+ */
+export interface UserProfile {
+  userId: string;
+  email: string;
+  preferredUsername: string;
+  displayName: string;
+  avatarUrl: string | null;
+  profileVisibility: ProfileVisibility;
+  bio?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Public-facing slice returned by `POST /users/get-by-handle`. Used to render
+ * other users' profiles — never exposes the email or any private data.
+ */
+export interface MinimalUser {
+  userId: string;
+  preferredUsername: string;
+  displayName: string;
+  avatarUrl: string | null;
+  profileVisibility: ProfileVisibility;
+}
+
+/** Whitelist of fields the user can self-edit via `POST /users/edit`. */
+export interface EditableFields {
+  displayName: string;
+  profileVisibility: ProfileVisibility;
+  avatarUrl: string | null;
+  bio: string | null;
+}
+
+/** S3 presigned upload pair returned by `POST /users/presign-avatar`. */
+export interface PresignAvatarResponse {
+  uploadUrl: string;
+  finalUrl: string;
+}

--- a/src/app/services/profile.service.ts
+++ b/src/app/services/profile.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { CognitoService } from './cognito.service';
+import { UsersService } from './users.service';
+import { UserProfile } from '../models/user.model';
+
+/**
+ * In-memory cache of the signed-in user's full profile (avatar, displayName,
+ * visibility, etc.). Auto-refreshes whenever Cognito reports a new auth
+ * state — sign-in fetches, sign-out clears.
+ *
+ * Subscribe to `profile$` from the header and profile page so they stay in
+ * sync after edits. After `edit()` succeeds, push the result through
+ * `setProfile()` to avoid a needless refetch.
+ */
+@Injectable({ providedIn: 'root' })
+export class ProfileService implements OnDestroy {
+  private readonly profileSubject = new BehaviorSubject<UserProfile | null>(null);
+  readonly profile$: Observable<UserProfile | null> = this.profileSubject.asObservable();
+
+  private authSub?: Subscription;
+
+  constructor(
+    private cognito: CognitoService,
+    private users: UsersService,
+  ) {
+    this.authSub = this.cognito.user$.subscribe((user) => {
+      if (user) {
+        this.refresh();
+      } else {
+        this.profileSubject.next(null);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.authSub?.unsubscribe();
+  }
+
+  get currentProfile(): UserProfile | null {
+    return this.profileSubject.value;
+  }
+
+  /** Imperatively refresh from the API. Errors are swallowed — header just stays stale. */
+  refresh(): void {
+    this.users.getMe().subscribe({
+      next: (profile) => this.profileSubject.next(profile),
+      error: () => {
+        // Likely first run before backend is wired up, or transient 5xx.
+        // Don't clobber any existing profile state.
+      },
+    });
+  }
+
+  /** Push an updated profile (e.g. after `users.edit(...)`) into the cache. */
+  setProfile(profile: UserProfile): void {
+    this.profileSubject.next(profile);
+  }
+}

--- a/src/app/services/users.service.ts
+++ b/src/app/services/users.service.ts
@@ -1,0 +1,90 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, from, of, switchMap } from 'rxjs';
+import { environment } from '../../environments/environment';
+import {
+  EditableFields,
+  MinimalUser,
+  PresignAvatarResponse,
+  UserProfile,
+} from '../models/user.model';
+
+/**
+ * Talks to the shared `xomware-users` service at `apiBaseUrl`. All endpoints
+ * are POST + JSON (consistent with the rest of the Xomware backend); the JWT
+ * is attached automatically by `jwtInterceptor`.
+ *
+ * Used by:
+ *   - Profile page (getMe, edit, uploadAvatar)
+ *   - Header (getMe via ProfileService)
+ *   - Public lookup of other users (getByHandle) — Phase 5+ surfaces.
+ */
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private readonly baseUrl = `${environment.usersApiUrl}/users`;
+
+  constructor(private http: HttpClient) {}
+
+  /** The authenticated caller's full profile (includes email + private fields). */
+  getMe(): Observable<UserProfile> {
+    return this.http.post<UserProfile>(`${this.baseUrl}/me`, {});
+  }
+
+  /**
+   * Public-facing lookup of any user by their `@handle` (preferred username).
+   * Always returns the minimal slice — never email — even for the caller.
+   */
+  getByHandle(handle: string): Observable<MinimalUser> {
+    return this.http.post<MinimalUser>(`${this.baseUrl}/get-by-handle`, {
+      handle,
+    });
+  }
+
+  /**
+   * Patch one or more editable fields. Backend validates `displayName`
+   * length and visibility enum; surfaces errors as 4xx.
+   */
+  edit(fields: Partial<EditableFields>): Observable<UserProfile> {
+    return this.http.post<UserProfile>(`${this.baseUrl}/edit`, fields);
+  }
+
+  /**
+   * Ask the backend for a presigned S3 PUT URL for an avatar of the given
+   * MIME type. The `finalUrl` is the public CDN URL the file will be served
+   * from once the PUT succeeds.
+   */
+  presignAvatar(contentType: string): Observable<PresignAvatarResponse> {
+    return this.http.post<PresignAvatarResponse>(
+      `${this.baseUrl}/presign-avatar`,
+      { contentType },
+    );
+  }
+
+  /**
+   * End-to-end avatar upload: presign → PUT to S3 → return the final CDN URL.
+   * Caller is responsible for calling `edit({ avatarUrl })` to persist it on
+   * the profile (kept separate so callers can preview before saving).
+   *
+   * Skips the JWT interceptor on the S3 PUT (URL-signed). Sends the same
+   * content type the presign was issued for — mismatches fail the signature.
+   */
+  uploadAvatar(file: File): Observable<string> {
+    return this.presignAvatar(file.type).pipe(
+      switchMap(({ uploadUrl, finalUrl }) =>
+        from(
+          fetch(uploadUrl, {
+            method: 'PUT',
+            headers: { 'Content-Type': file.type },
+            body: file,
+          }).then((res) => {
+            if (!res.ok) {
+              throw new Error(`Avatar upload failed: ${res.status}`);
+            }
+            return finalUrl;
+          }),
+        ),
+      ),
+      switchMap((url) => of(url)),
+    );
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,8 @@
 export const environment = {
   production: true,
   apiBaseUrl: 'https://editor-api.xomware.com',
+  usersApiUrl: 'https://api.xomware.com',
+  avatarsCdnUrl: '',
   awsRegion: 'us-east-1',
   cognitoUserPoolId: '',
   cognitoClientId: '',


### PR DESCRIPTION
## Summary
- Real `/profile` page replacing the Phase 2 stub: large avatar with coral-initial fallback, `@handle`, displayName, email, profile-visibility badge, 0/0/0/0 stats placeholders, edit + sign-out actions.
- Edit profile modal: displayName (1–50), public/private radios, direct-to-S3 avatar upload via presigned PUT (PNG/JPG/WebP). Saved on submit through `POST /users/edit`.
- Header user menu now shows the avatar (or coral initial) alongside `@handle` and links to `/profile`.
- New `UsersService` (`getMe`, `getByHandle`, `edit`, `presignAvatar`, `uploadAvatar`) + `ProfileService` cache that refreshes off `CognitoService.user$`.
- `jwtInterceptor` attaches the Cognito ID token to `api.xomware.com` calls and skips presigned S3 PUTs (URL-signed).
- `environment(.local).ts` gains `usersApiUrl` + `avatarsCdnUrl`. Deploy workflow pulls them from `/xomware/shared/users-api/url` and `/xomware/shared/avatars/cdn-url` and `sed`s them into `environment.ts` alongside the existing Cognito values.

## Do NOT merge
Wait for the infra side (xomware-users service + SSM params + CDN bucket) to apply first. This PR is staged so the build is ready to flip the moment infra is live.

## Test plan
- [ ] Infra applied: `/xomware/shared/users-api/url`, `/xomware/shared/avatars/cdn-url`, plus the four `POST /users/*` routes responding on `api.xomware.com`
- [ ] Sign in on xomware.com → header shows coral-initial avatar + `@handle`
- [ ] `/profile` loads the signed-in user (avatar, name, email, visibility)
- [ ] Edit profile → change displayName + flip visibility → Save → header updates without a refresh
- [ ] Upload PNG / JPG / WebP avatar → preview shows pre-save → Save persists
- [ ] Reject non-image / wrong-MIME files with the inline error
- [ ] Sign out clears the cached profile (header reverts to "Sign in")
- [ ] Build: `npx ng build --configuration production` (already verified locally, ~4.5s)