### PR TITLE
chore: migrate file-editor API calls from api.xomware.com to editor-api.xomware.com

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -39,6 +39,7 @@ jobs:
             echo "COGNITO_USER_POOL_ID=$(aws ssm get-parameter --name /xomware/shared/cognito/user-pool-id --query Parameter.Value --output text)"
             echo "COGNITO_CLIENT_ID=$(aws ssm get-parameter --name /xomware/shared/cognito/clients/xomware-com-id --query Parameter.Value --output text)"
             echo "COGNITO_DOMAIN=$(aws ssm get-parameter --name /xomware/shared/cognito/hosted-ui-domain --query Parameter.Value --output text)"
+            echo "FILE_EDITOR_API_URL=$(aws ssm get-parameter --name /xomware/shared/file-editor-api/url --query Parameter.Value --output text)"
           } >> "$GITHUB_ENV"
 
       - name: Inject environment variables into Angular
@@ -52,6 +53,14 @@ jobs:
           sed -i "s|cognitoClientId: ''|cognitoClientId: '${COGNITO_CLIENT_ID}'|g" src/environments/environment.ts
           sed -i "s|cognitoDomain: 'xomware-auth.auth.us-east-1.amazoncognito.com'|cognitoDomain: '${COGNITO_DOMAIN}'|g" src/environments/environment.ts
           sed -i "s|ga4MeasurementId: ''|ga4MeasurementId: '${GA4_MEASUREMENT_ID}'|g" src/environments/environment.ts
+          # File-editor API URL comes from /xomware/shared/file-editor-api/url
+          # (Command Center backend, migrated from api.xomware.com to
+          # editor-api.xomware.com). Default in environment.ts is the new
+          # domain so the build still works if SSM is empty during a
+          # transitional deploy.
+          if [ -n "${FILE_EDITOR_API_URL}" ]; then
+            sed -i "s|apiBaseUrl: 'https://editor-api.xomware.com'|apiBaseUrl: '${FILE_EDITOR_API_URL}'|g" src/environments/environment.ts
+          fi
 
       - name: Build
         run: npm run build:prod

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://api.xomware.com',
+  apiBaseUrl: 'https://editor-api.xomware.com',
   awsRegion: 'us-east-1',
   cognitoUserPoolId: '',
   cognitoClientId: '',


### PR DESCRIPTION
## Summary

- Update Command Center API calls to point at the new `editor-api.xomware.com` domain (was `api.xomware.com`)
- Add SSM-driven injection of `FILE_EDITOR_API_URL` in the deploy workflow, matching the existing Cognito pattern

## Why

The shared Xomware infra is migrating the file-editor (Command Center backend) custom domain from `api.xomware.com` to `editor-api.xomware.com` so `api.xomware.com` is free for the new shared users service. See companion infra PR.

## Test plan

- [ ] Verify build succeeds with default `editor-api.xomware.com` (transitional safety)
- [ ] Verify post-merge deploy reads `/xomware/shared/file-editor-api/url` from SSM and injects into `environment.ts`
- [ ] Verify Command Center pages (`/command`, `/status/board`, `/infra/*`) reach the new endpoint
- [ ] Merge AFTER the infra PR so SSM param + DNS exist