### PR TITLE
fix(auth): test err.name + surface raw error fallback

### DIFF
--- a/src/app/components/auth/forgot-password/forgot-password.component.ts
+++ b/src/app/components/auth/forgot-password/forgot-password.component.ts
@@ -88,16 +88,18 @@ export class ForgotPasswordComponent {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/UserNotFoundException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/UserNotFoundException/i.test(both))
       return 'No account found for that email.';
-    if (/CodeMismatchException/i.test(msg)) return 'That code is incorrect.';
-    if (/ExpiredCodeException/i.test(msg))
+    if (/CodeMismatchException/i.test(both)) return 'That code is incorrect.';
+    if (/ExpiredCodeException/i.test(both))
       return 'That code expired — request a new one.';
-    if (/InvalidPasswordException/i.test(msg))
+    if (/InvalidPasswordException/i.test(both))
       return 'Password does not meet the requirements.';
-    if (/LimitExceededException/i.test(msg))
+    if (/LimitExceededException/i.test(both))
       return 'Too many attempts. Please wait and try again.';
-    return 'Something went wrong. Please try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/sign-in/sign-in.component.ts
+++ b/src/app/components/auth/sign-in/sign-in.component.ts
@@ -80,13 +80,15 @@ export class SignInComponent implements OnInit {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/NotAuthorizedException|Incorrect/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/NotAuthorizedException|Incorrect/i.test(both))
       return 'Email or password is incorrect.';
-    if (/UserNotFoundException/i.test(msg)) return 'No account found for that email.';
-    if (/UserNotConfirmedException/i.test(msg))
+    if (/UserNotFoundException/i.test(both)) return 'No account found for that email.';
+    if (/UserNotConfirmedException/i.test(both))
       return 'Please verify your email before signing in.';
-    if (/network/i.test(msg)) return 'Network error — check your connection and try again.';
-    return 'Something went wrong. Please try again.';
+    if (/network/i.test(both)) return 'Network error — check your connection and try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/sign-up/sign-up.component.ts
+++ b/src/app/components/auth/sign-up/sign-up.component.ts
@@ -87,13 +87,15 @@ export class SignUpComponent {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/UsernameExistsException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/UsernameExistsException/i.test(both))
       return 'An account already exists for that email.';
-    if (/InvalidPasswordException/i.test(msg))
+    if (/InvalidPasswordException/i.test(both))
       return 'Password does not meet the requirements.';
-    if (/InvalidParameterException/i.test(msg))
+    if (/InvalidParameterException/i.test(both))
       return 'One of the fields is invalid. Please check and try again.';
-    return 'Something went wrong. Please try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/verify/verify.component.ts
+++ b/src/app/components/auth/verify/verify.component.ts
@@ -96,12 +96,23 @@ export class VerifyComponent implements OnInit {
   }
 
   private friendlyError(err: Error): string {
+    // Amplify v6 errors carry the Cognito exception name in `err.name`,
+    // not in `err.message`. Test both so we don't fall through to the
+    // generic catch-all silently.
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/CodeMismatchException/i.test(msg)) return 'That code is incorrect.';
-    if (/ExpiredCodeException/i.test(msg))
-      return 'That code expired — request a new one.';
-    if (/LimitExceededException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/CodeMismatchException/i.test(both)) return 'That code is incorrect.';
+    if (/ExpiredCodeException/i.test(both))
+      return 'That code expired or was wrong. Request a new one.';
+    if (/LimitExceededException/i.test(both))
       return 'Too many attempts. Please wait and try again.';
-    return 'Something went wrong. Please try again.';
+    if (/NotAuthorizedException/i.test(both)) {
+      if (/already confirmed/i.test(msg)) return 'Already confirmed — go sign in.';
+      return msg || 'Not authorized.';
+    }
+    if (/UserNotFoundException/i.test(both)) return 'No account for that email.';
+    // Fallback: surface the raw error so we can diagnose it.
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }


### PR DESCRIPTION
Same fix across all 4 auth components — verify, sign-up, sign-in, forgot-password. Real Cognito errors will now appear on the screen instead of 'Something went wrong.'