### PR TITLE
fix(auth): thread Cognito Username UUID through sign-up → verify

### DIFF
--- a/src/app/components/auth/forgot-password/forgot-password.component.ts
+++ b/src/app/components/auth/forgot-password/forgot-password.component.ts
@@ -88,16 +88,18 @@ export class ForgotPasswordComponent {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/UserNotFoundException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/UserNotFoundException/i.test(both))
       return 'No account found for that email.';
-    if (/CodeMismatchException/i.test(msg)) return 'That code is incorrect.';
-    if (/ExpiredCodeException/i.test(msg))
+    if (/CodeMismatchException/i.test(both)) return 'That code is incorrect.';
+    if (/ExpiredCodeException/i.test(both))
       return 'That code expired — request a new one.';
-    if (/InvalidPasswordException/i.test(msg))
+    if (/InvalidPasswordException/i.test(both))
       return 'Password does not meet the requirements.';
-    if (/LimitExceededException/i.test(msg))
+    if (/LimitExceededException/i.test(both))
       return 'Too many attempts. Please wait and try again.';
-    return 'Something went wrong. Please try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/sign-in/sign-in.component.ts
+++ b/src/app/components/auth/sign-in/sign-in.component.ts
@@ -80,13 +80,15 @@ export class SignInComponent implements OnInit {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/NotAuthorizedException|Incorrect/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/NotAuthorizedException|Incorrect/i.test(both))
       return 'Email or password is incorrect.';
-    if (/UserNotFoundException/i.test(msg)) return 'No account found for that email.';
-    if (/UserNotConfirmedException/i.test(msg))
+    if (/UserNotFoundException/i.test(both)) return 'No account found for that email.';
+    if (/UserNotConfirmedException/i.test(both))
       return 'Please verify your email before signing in.';
-    if (/network/i.test(msg)) return 'Network error — check your connection and try again.';
-    return 'Something went wrong. Please try again.';
+    if (/network/i.test(both)) return 'Network error — check your connection and try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/sign-up/sign-up.component.ts
+++ b/src/app/components/auth/sign-up/sign-up.component.ts
@@ -87,13 +87,15 @@ export class SignUpComponent {
   }
 
   private friendlyError(err: Error): string {
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/UsernameExistsException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/UsernameExistsException/i.test(both))
       return 'An account already exists for that email.';
-    if (/InvalidPasswordException/i.test(msg))
+    if (/InvalidPasswordException/i.test(both))
       return 'Password does not meet the requirements.';
-    if (/InvalidParameterException/i.test(msg))
+    if (/InvalidParameterException/i.test(both))
       return 'One of the fields is invalid. Please check and try again.';
-    return 'Something went wrong. Please try again.';
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/components/auth/sign-up/sign-up.component.ts
+++ b/src/app/components/auth/sign-up/sign-up.component.ts
@@ -75,9 +75,15 @@ export class SignUpComponent {
     };
 
     this.cognito.signUp(email, password, preferredUsername).subscribe({
-      next: () => {
+      next: ({ username }) => {
         this.analytics.track('sign_up', { method: 'cognito' });
-        this.router.navigate(['/auth/verify'], { queryParams: { email } });
+        // Pass the opaque Username (UUID) to verify so confirmSignUp can
+        // address the user directly — email aliases aren't reliable on
+        // unconfirmed accounts (multiple unconfirmed users can share an
+        // email; alias-resolution returns ambiguous and 400s the verify).
+        this.router.navigate(['/auth/verify'], {
+          queryParams: { email, username },
+        });
       },
       error: (err: Error) => {
         this.loading = false;

--- a/src/app/components/auth/verify/verify.component.ts
+++ b/src/app/components/auth/verify/verify.component.ts
@@ -16,6 +16,9 @@ export class VerifyComponent implements OnInit {
   errorMessage = '';
   infoMessage = '';
   email = '';
+  /** Opaque Cognito Username from sign-up. confirmSignUp uses this directly
+   * — alias resolution by email isn't reliable for unconfirmed users. */
+  private username = '';
   /** Forwarded to sign-in after verify so the auth-gate `next` survives sign-up→verify→sign-in. */
   private nextPath: string | null = null;
 
@@ -33,6 +36,7 @@ export class VerifyComponent implements OnInit {
 
   ngOnInit(): void {
     this.email = this.route.snapshot.queryParamMap.get('email') ?? '';
+    this.username = this.route.snapshot.queryParamMap.get('username') ?? '';
     const raw = this.route.snapshot.queryParamMap.get('next');
     if (raw && raw.startsWith('/') && !raw.startsWith('//')) {
       this.nextPath = raw;
@@ -45,8 +49,8 @@ export class VerifyComponent implements OnInit {
   }
 
   onSubmit(): void {
-    if (!this.email) {
-      this.errorMessage = 'Missing email — go back and start sign-up again.';
+    if (!this.username && !this.email) {
+      this.errorMessage = 'Missing identifier — go back and start sign-up again.';
       return;
     }
     if (this.form.invalid || this.loading) {
@@ -57,8 +61,13 @@ export class VerifyComponent implements OnInit {
     this.errorMessage = '';
     this.infoMessage = '';
     const { code } = this.form.value as { code: string };
+    // Prefer the UUID Username (set by sign-up). Fall back to email only
+    // if the user landed here by direct URL — works for confirmed users
+    // resending codes, but unreliable when multiple unconfirmed accounts
+    // share an email.
+    const identifier = this.username || this.email;
 
-    this.cognito.confirmSignUp(this.email, code).subscribe({
+    this.cognito.confirmSignUp(identifier, code).subscribe({
       next: (confirmed) => {
         this.loading = false;
         if (confirmed) {
@@ -78,12 +87,13 @@ export class VerifyComponent implements OnInit {
   }
 
   onResend(): void {
-    if (!this.email || this.resending) return;
+    if ((!this.username && !this.email) || this.resending) return;
     this.resending = true;
     this.errorMessage = '';
     this.infoMessage = '';
+    const identifier = this.username || this.email;
 
-    this.cognito.resendCode(this.email).subscribe({
+    this.cognito.resendCode(identifier).subscribe({
       next: () => {
         this.resending = false;
         this.infoMessage = 'A new code is on its way.';

--- a/src/app/components/auth/verify/verify.component.ts
+++ b/src/app/components/auth/verify/verify.component.ts
@@ -96,12 +96,23 @@ export class VerifyComponent implements OnInit {
   }
 
   private friendlyError(err: Error): string {
+    // Amplify v6 errors carry the Cognito exception name in `err.name`,
+    // not in `err.message`. Test both so we don't fall through to the
+    // generic catch-all silently.
+    const name = (err as { name?: string }).name || '';
     const msg = err.message || '';
-    if (/CodeMismatchException/i.test(msg)) return 'That code is incorrect.';
-    if (/ExpiredCodeException/i.test(msg))
-      return 'That code expired — request a new one.';
-    if (/LimitExceededException/i.test(msg))
+    const both = `${name} ${msg}`;
+    if (/CodeMismatchException/i.test(both)) return 'That code is incorrect.';
+    if (/ExpiredCodeException/i.test(both))
+      return 'That code expired or was wrong. Request a new one.';
+    if (/LimitExceededException/i.test(both))
       return 'Too many attempts. Please wait and try again.';
-    return 'Something went wrong. Please try again.';
+    if (/NotAuthorizedException/i.test(both)) {
+      if (/already confirmed/i.test(msg)) return 'Already confirmed — go sign in.';
+      return msg || 'Not authorized.';
+    }
+    if (/UserNotFoundException/i.test(both)) return 'No account for that email.';
+    // Fallback: surface the raw error so we can diagnose it.
+    return msg ? `${name ? name + ': ' : ''}${msg}` : 'Something went wrong. Please try again.';
   }
 }

--- a/src/app/services/cognito.service.ts
+++ b/src/app/services/cognito.service.ts
@@ -101,19 +101,17 @@ export class CognitoService implements OnDestroy {
     email: string,
     password: string,
     preferredUsername: string,
-  ): Observable<{ userConfirmed: boolean }> {
-    // The shared pool uses alias_attributes = ["email", "preferred_username"]
-    // (Option B), which means the underlying Cognito Username CANNOT be in
-    // email format. Generate an opaque UUID — sign-in still works with email
-    // because email is an alias.
+  ): Observable<{ userConfirmed: boolean; username: string }> {
+    // Pool config: alias_attributes = ["email"]. Cognito Username must be
+    // opaque (NOT email-format). Generate a UUID. Caller stores it and
+    // passes it back to confirmSignUp — alias resolution can't be used
+    // for unconfirmed users, since email-uniqueness is only enforced
+    // post-confirmation (a retry would otherwise create a parallel
+    // unconfirmed user with the same email and break verify).
     const opaqueUsername =
       typeof crypto !== 'undefined' && crypto.randomUUID
         ? crypto.randomUUID()
         : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    // preferred_username can't be a userAttribute during SignUp because
-    // alias_attributes includes it (Cognito reserves alias attrs for
-    // confirmed accounts only). Pass via clientMetadata; the PostConfirmation
-    // Lambda picks it up after the email is verified.
     return from(
       signUp({
         username: opaqueUsername,
@@ -122,11 +120,17 @@ export class CognitoService implements OnDestroy {
           userAttributes: {
             email,
           },
+          // preferred_username can't be a SignUp userAttribute (alias
+          // reserved for confirmed accounts). Forward via clientMetadata;
+          // the PostConfirmation Lambda picks it up.
           clientMetadata: {
             preferred_username: preferredUsername,
           },
         },
-      }).then((res) => ({ userConfirmed: !!res.isSignUpComplete })),
+      }).then((res) => ({
+        userConfirmed: !!res.isSignUpComplete,
+        username: opaqueUsername,
+      })),
     );
   }
 


### PR DESCRIPTION
Cognito email aliases aren't reliable on UNCONFIRMED users. Three duplicate UNCONFIRMED accounts piled up under domjgiordano@gmail.com because each retry created a new user; verify hit ambiguous alias resolution and 400'd. Pass UUID through queryparams instead.