### PR TITLE
Phase 4 (frontend): activate Google sign-in

### DIFF
--- a/src/app/components/auth/sign-in/sign-in.component.ts
+++ b/src/app/components/auth/sign-in/sign-in.component.ts
@@ -74,9 +74,19 @@ export class SignInComponent implements OnInit {
   }
 
   onGoogleSignIn(): void {
-    // Phase 4 stub — UI present, click is a no-op so the layout is final but
-    // we don't kick off OAuth until Google is registered as a federated IdP.
-    this.errorMessage = 'Google sign-in is coming soon.';
+    // Phase 4: kick off the Google OAuth redirect through Cognito Hosted UI.
+    // The PreSignUp Lambda links to an existing local account if one exists.
+    if (this.loading) return;
+    this.loading = true;
+    this.errorMessage = '';
+    this.analytics.track('login_initiate', { method: 'google' });
+    this.cognito.signInWithGoogle().subscribe({
+      // No `next` handler needed — Amplify navigates the page to Google.
+      error: (err: Error) => {
+        this.loading = false;
+        this.errorMessage = this.friendlyError(err);
+      },
+    });
   }
 
   private friendlyError(err: Error): string {

--- a/src/app/components/auth/sign-up/sign-up.component.html
+++ b/src/app/components/auth/sign-up/sign-up.component.html
@@ -71,6 +71,18 @@
         <span *ngIf="!loading">Create account</span>
         <span *ngIf="loading" class="spinner" aria-label="Creating account"></span>
       </button>
+
+      <div class="auth-divider"><span>or</span></div>
+
+      <button type="button" class="auth-btn-ghost" (click)="onGoogleSignIn()" [disabled]="loading">
+        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="#fff" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.56c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+          <path fill="#fff" opacity=".75" d="M12 23c2.97 0 5.46-.98 7.28-2.65l-3.56-2.77c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z"/>
+          <path fill="#fff" opacity=".5" d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.74.13-1.45.34-2.11V7.05H2.18a11 11 0 0 0 0 9.9l3.66-2.84z"/>
+          <path fill="#fff" opacity=".25" d="M12 5.38c1.62 0 3.07.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"/>
+        </svg>
+        Continue with Google
+      </button>
     </form>
 
     <p class="auth-footer">

--- a/src/app/components/auth/sign-up/sign-up.component.ts
+++ b/src/app/components/auth/sign-up/sign-up.component.ts
@@ -92,6 +92,22 @@ export class SignUpComponent {
     });
   }
 
+  onGoogleSignIn(): void {
+    // Phase 4: kick off the Google OAuth redirect through Cognito Hosted UI.
+    // The PreSignUp Lambda links to an existing local account if one exists.
+    if (this.loading) return;
+    this.loading = true;
+    this.errorMessage = '';
+    this.analytics.track('sign_up_initiate', { method: 'google' });
+    this.cognito.signInWithGoogle().subscribe({
+      // No `next` handler needed — Amplify navigates the page to Google.
+      error: (err: Error) => {
+        this.loading = false;
+        this.errorMessage = this.friendlyError(err);
+      },
+    });
+  }
+
   private friendlyError(err: Error): string {
     const name = (err as { name?: string }).name || '';
     const msg = err.message || '';


### PR DESCRIPTION
## Summary

Companion to xomware-infrastructure#33. The CognitoService already exposed a working signInWithGoogle() wired to Amplify's signInWithRedirect({ provider: 'Google' }); the click handlers in sign-in/sign-up just needed to call it instead of showing a 'coming soon' error.

- sign-in.component.ts: onGoogleSignIn() now calls the service (was a no-op error message).
- sign-up.component.ts + .html: adds Continue with Google button + divider for parity with sign-in.

Depends on the infra PR being merged + applied first (Google IdP must exist on the pool before redirect succeeds).

## Test plan

- [ ] After infra apply, click Continue with Google on https://xomware.com/auth/sign-in -> Google consent -> redirected to /auth/callback -> signed in
- [ ] Same from /auth/sign-up
- [ ] Existing email-password user signs in with Google using same email -> linked, no duplicate; profile still works