### PR TITLE
feat(admin): /admin portal — events log + cost summary

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,12 +5,14 @@ import { CommandCenterComponent } from './components/command-center/command-cent
 import { AuthGateComponent } from './components/command-center/auth-gate/auth-gate.component';
 import { AuthGuard } from './guards/auth.guard';
 import { cognitoAuthGuard } from './guards/cognito-auth.guard';
+import { adminGuard } from './guards/admin.guard';
 import { SignInComponent } from './components/auth/sign-in/sign-in.component';
 import { SignUpComponent } from './components/auth/sign-up/sign-up.component';
 import { VerifyComponent } from './components/auth/verify/verify.component';
 import { ForgotPasswordComponent } from './components/auth/forgot-password/forgot-password.component';
 import { CallbackComponent } from './components/auth/callback/callback.component';
 import { ProfileComponent } from './components/auth/profile/profile.component';
+import { AdminComponent } from './components/admin/admin.component';
 
 const routes: Routes = [
   { path: '', component: LandingComponent, canActivate: [cognitoAuthGuard] },
@@ -22,6 +24,7 @@ const routes: Routes = [
   { path: 'profile', component: ProfileComponent },
   { path: 'command/login', component: AuthGateComponent },
   { path: 'command', component: CommandCenterComponent, canActivate: [AuthGuard] },
+  { path: 'admin', component: AdminComponent, canActivate: [adminGuard] },
   { path: '**', redirectTo: '' },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { VerifyComponent } from './components/auth/verify/verify.component';
 import { ForgotPasswordComponent } from './components/auth/forgot-password/forgot-password.component';
 import { CallbackComponent } from './components/auth/callback/callback.component';
 import { ProfileComponent } from './components/auth/profile/profile.component';
+import { AdminComponent } from './components/admin/admin.component';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import { ProfileComponent } from './components/auth/profile/profile.component';
     ForgotPasswordComponent,
     CallbackComponent,
     ProfileComponent,
+    AdminComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/admin/admin.component.html
+++ b/src/app/components/admin/admin.component.html
@@ -1,0 +1,151 @@
+<div class="admin">
+  <header class="admin-header">
+    <div class="admin-header-left">
+      <a routerLink="/" class="admin-logo" aria-label="Back to Xomware home">
+        <img src="assets/img/xomware-icon-transparent-background.png" alt="Xomware" />
+      </a>
+      <h1 class="admin-title">Admin</h1>
+    </div>
+    <div class="admin-header-right">
+      <button type="button" class="admin-signout" (click)="signOut()">Sign out</button>
+    </div>
+  </header>
+
+  <main class="admin-content">
+    <div class="admin-grid">
+      <!-- Events card -->
+      <section class="card events-card" aria-labelledby="events-heading">
+        <div class="card-header">
+          <div>
+            <h2 id="events-heading">Events</h2>
+            <p class="card-subtitle">Recent sign-ins and sign-ups</p>
+          </div>
+          <form
+            class="date-form"
+            [formGroup]="dateForm"
+            (ngSubmit)="loadEvents()"
+          >
+            <label class="visually-hidden" for="events-date">Date</label>
+            <input
+              id="events-date"
+              type="date"
+              class="date-input"
+              formControlName="date"
+            />
+            <button
+              type="submit"
+              class="btn btn-primary"
+              [disabled]="eventsLoading"
+            >
+              {{ eventsLoading ? 'Loading…' : 'Load' }}
+            </button>
+          </form>
+        </div>
+
+        <div *ngIf="eventsError" class="error-banner" role="alert">
+          <span>{{ eventsError }}</span>
+          <button type="button" class="btn-link" (click)="loadEvents()">Retry</button>
+        </div>
+
+        <div *ngIf="eventsLoading && events.length === 0" class="loading-state">
+          Loading events…
+        </div>
+
+        <div
+          *ngIf="!eventsLoading && events.length === 0 && !eventsError"
+          class="empty-state"
+        >
+          No events for {{ eventsDate || (dateForm.value.date) }}.
+        </div>
+
+        <div *ngIf="events.length > 0" class="events-table" role="table">
+          <div class="events-row events-head" role="row">
+            <span class="col-time" role="columnheader">Time</span>
+            <span class="col-type" role="columnheader">Type</span>
+            <span class="col-email" role="columnheader">Email</span>
+            <span class="col-idp" role="columnheader">Provider</span>
+          </div>
+          <div
+            *ngFor="let ev of events"
+            class="events-row"
+            role="row"
+          >
+            <span class="col-time" role="cell">{{ formatTime(ev.eventTime) }}</span>
+            <span class="col-type" role="cell">
+              <span
+                class="pill"
+                [class.pill-signin]="ev.eventType === 'signin'"
+                [class.pill-signup]="ev.eventType === 'signup'"
+              >{{ ev.eventType }}</span>
+            </span>
+            <span class="col-email" role="cell">{{ ev.email || '—' }}</span>
+            <span class="col-idp" role="cell">{{ ev.identityProvider || '—' }}</span>
+          </div>
+        </div>
+
+        <div class="card-footer" *ngIf="eventsCursor">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            (click)="loadMoreEvents()"
+            [disabled]="eventsLoadingMore"
+          >
+            {{ eventsLoadingMore ? 'Loading…' : 'Load more' }}
+          </button>
+        </div>
+      </section>
+
+      <!-- Cost card -->
+      <section class="card cost-card" aria-labelledby="cost-heading">
+        <div class="card-header">
+          <div>
+            <h2 id="cost-heading">Month-to-date cost</h2>
+            <p class="card-subtitle">
+              <ng-container *ngIf="cost; else costSubtitleFallback">
+                {{ formatRange(cost.start, cost.end) }}
+              </ng-container>
+              <ng-template #costSubtitleFallback>AWS spend, current period</ng-template>
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            (click)="loadCost()"
+            [disabled]="costLoading"
+          >
+            {{ costLoading ? 'Refreshing…' : 'Refresh' }}
+          </button>
+        </div>
+
+        <div *ngIf="costError" class="error-banner" role="alert">
+          <span>{{ costError }}</span>
+          <button type="button" class="btn-link" (click)="loadCost()">Retry</button>
+        </div>
+
+        <div *ngIf="costLoading && !cost" class="loading-state">
+          Loading cost…
+        </div>
+
+        <ng-container *ngIf="cost && !costLoading">
+          <div class="cost-total-row">
+            <span class="cost-total">{{ formatMoney(cost.total, cost.currency) }}</span>
+            <span *ngIf="cost.cached" class="pill pill-cached">cached</span>
+          </div>
+
+          <div class="cost-services">
+            <div
+              *ngFor="let svc of cost.services"
+              class="cost-row"
+            >
+              <span class="cost-service">{{ svc.service }}</span>
+              <span class="cost-amount">{{ formatMoney(svc.amount, cost.currency) }}</span>
+            </div>
+            <div *ngIf="cost.services.length === 0" class="empty-state-small">
+              No services billed yet.
+            </div>
+          </div>
+        </ng-container>
+      </section>
+    </div>
+  </main>
+</div>

--- a/src/app/components/admin/admin.component.scss
+++ b/src/app/components/admin/admin.component.scss
@@ -1,0 +1,411 @@
+@import 'styles/variables';
+
+:host {
+  display: block;
+}
+
+.admin {
+  min-height: 100vh;
+  background: $bg-dark;
+  display: flex;
+  flex-direction: column;
+  font-family: $font-stack;
+}
+
+.admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-sm $spacing-lg;
+  background: rgba($bg-card, 0.95);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.admin-header-left {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+}
+
+.admin-logo img {
+  width: 32px;
+  height: 32px;
+  filter: drop-shadow(0 0 8px $brand-cyan-glow);
+}
+
+.admin-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: $text-primary;
+  white-space: nowrap;
+  margin: 0;
+}
+
+.admin-signout {
+  padding: $spacing-xs $spacing-md;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: $radius-md;
+  color: $text-muted;
+  font-size: 0.8rem;
+  font-family: $font-stack;
+  cursor: pointer;
+  transition: all $transition-base;
+
+  &:hover {
+    border-color: rgba(255, 82, 82, 0.4);
+    color: #ff5252;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
+  }
+}
+
+.admin-content {
+  flex: 1;
+  padding: $spacing-lg;
+  overflow-y: auto;
+}
+
+.admin-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: $spacing-md;
+}
+
+// --- Cards ---
+.card {
+  background: $card-gradient;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-lg;
+  padding: $spacing-md $spacing-lg;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+
+  h2 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: $text-primary;
+    margin: 0;
+  }
+}
+
+.card-subtitle {
+  font-size: 0.8rem;
+  color: $text-muted;
+  margin: $spacing-xs 0 0;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: center;
+  padding-top: $spacing-xs;
+}
+
+// --- Date form ---
+.date-form {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+.date-input {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: $radius-md;
+  color: $text-primary;
+  padding: $spacing-xs $spacing-sm;
+  font-size: 0.8rem;
+  font-family: $font-stack;
+  outline: none;
+  color-scheme: dark;
+
+  &:focus {
+    border-color: $brand-cyan;
+    box-shadow: 0 0 0 2px $brand-cyan-glow;
+  }
+}
+
+// --- Buttons ---
+.btn {
+  border-radius: $radius-md;
+  padding: $spacing-xs $spacing-md;
+  font-size: 0.8rem;
+  font-family: $font-stack;
+  cursor: pointer;
+  transition: all $transition-fast;
+  border: 1px solid transparent;
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-primary {
+  background: $cyan-accent;
+  color: $bg-dark;
+  font-weight: 600;
+
+  &:hover:not(:disabled) {
+    box-shadow: $shadow-glow-cyan;
+  }
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: $text-secondary;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.1);
+    color: $text-primary;
+  }
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: $brand-cyan;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+// --- States ---
+.error-banner {
+  background: rgba(255, 77, 109, 0.1);
+  border: 1px solid rgba(255, 77, 109, 0.3);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  color: #ff4d6d;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-sm;
+}
+
+.loading-state {
+  text-align: center;
+  color: $text-muted;
+  padding: $spacing-xl;
+  font-size: 0.9rem;
+}
+
+.empty-state {
+  text-align: center;
+  color: $text-muted;
+  padding: $spacing-lg;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: $radius-md;
+}
+
+.empty-state-small {
+  text-align: center;
+  color: $text-muted;
+  font-size: 0.8rem;
+  padding: $spacing-md;
+}
+
+// --- Events table ---
+.events-table {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-md;
+  overflow: hidden;
+}
+
+.events-row {
+  display: grid;
+  grid-template-columns: 100px 100px 1.6fr 1fr;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  font-size: 0.8rem;
+  color: $text-secondary;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.events-head {
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: $text-muted;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.col-time {
+  font-family: $font-mono;
+  font-size: 0.75rem;
+  color: $text-muted;
+}
+
+.col-email {
+  font-family: $font-mono;
+  font-size: 0.75rem;
+  color: $text-primary;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-idp {
+  font-size: 0.75rem;
+  color: $text-secondary;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// --- Pills ---
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px $spacing-sm;
+  border-radius: $radius-pill;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.pill-signin {
+  background: $brand-cyan-subtle;
+  color: $brand-cyan-light;
+  border: 1px solid rgba(0, 180, 216, 0.3);
+}
+
+.pill-signup {
+  background: rgba(0, 255, 171, 0.08);
+  color: $xomper-emerald;
+  border: 1px solid rgba(0, 255, 171, 0.3);
+}
+
+.pill-cached {
+  background: rgba(255, 255, 255, 0.05);
+  color: $text-muted;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+// --- Cost ---
+.cost-total-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+.cost-total {
+  font-size: 2rem;
+  font-weight: 700;
+  color: $brand-cyan;
+  font-family: $font-mono;
+  line-height: 1.2;
+}
+
+.cost-services {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-md;
+  overflow: hidden;
+}
+
+.cost-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-sm $spacing-md;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  font-size: 0.85rem;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.cost-service {
+  color: $text-secondary;
+}
+
+.cost-amount {
+  color: $text-primary;
+  font-family: $font-mono;
+  font-weight: 600;
+}
+
+// --- A11y helper ---
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// --- Responsive ---
+@media (max-width: $breakpoint-lg) {
+  .admin-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: $breakpoint-md) {
+  .admin-content {
+    padding: $spacing-sm;
+  }
+
+  .admin-header {
+    padding: $spacing-sm;
+  }
+
+  .events-row {
+    grid-template-columns: 80px 80px 1fr;
+
+    .col-idp {
+      display: none;
+    }
+  }
+
+  .events-head .col-idp {
+    display: none;
+  }
+
+  .cost-total {
+    font-size: 1.5rem;
+  }
+}

--- a/src/app/components/admin/admin.component.ts
+++ b/src/app/components/admin/admin.component.ts
@@ -1,0 +1,164 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import {
+  AdminEvent,
+  AdminService,
+  CostSummaryResponse,
+  EventsListResponse,
+} from '../../services/admin.service';
+import { CognitoService } from '../../services/cognito.service';
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.scss'],
+})
+export class AdminComponent implements OnInit {
+  readonly dateForm: FormGroup;
+
+  events: AdminEvent[] = [];
+  eventsDate = '';
+  eventsCursor: string | undefined;
+  eventsLoading = false;
+  eventsLoadingMore = false;
+  eventsError = '';
+
+  cost: CostSummaryResponse | null = null;
+  costLoading = false;
+  costError = '';
+
+  constructor(
+    private admin: AdminService,
+    private cognito: CognitoService,
+    private fb: FormBuilder,
+    private router: Router,
+  ) {
+    this.dateForm = this.fb.group({
+      date: [this.todayIso()],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadEvents();
+    this.loadCost();
+  }
+
+  loadEvents(): void {
+    const date = this.dateForm.value.date as string | null;
+    this.eventsLoading = true;
+    this.eventsError = '';
+    this.events = [];
+    this.eventsCursor = undefined;
+
+    this.admin.listEvents(date ? { date } : {}).subscribe({
+      next: (res: EventsListResponse) => {
+        this.events = res.items;
+        this.eventsCursor = res.nextCursor;
+        this.eventsDate = res.date;
+        this.eventsLoading = false;
+      },
+      error: (err) => {
+        this.eventsError = this.errorMessage(err, 'Failed to load events');
+        this.eventsLoading = false;
+      },
+    });
+  }
+
+  loadMoreEvents(): void {
+    if (!this.eventsCursor || this.eventsLoadingMore) {
+      return;
+    }
+    this.eventsLoadingMore = true;
+    const date = this.eventsDate || (this.dateForm.value.date as string);
+
+    this.admin
+      .listEvents({ date, cursor: this.eventsCursor })
+      .subscribe({
+        next: (res: EventsListResponse) => {
+          this.events = [...this.events, ...res.items];
+          this.eventsCursor = res.nextCursor;
+          this.eventsLoadingMore = false;
+        },
+        error: (err) => {
+          this.eventsError = this.errorMessage(err, 'Failed to load more events');
+          this.eventsLoadingMore = false;
+        },
+      });
+  }
+
+  loadCost(): void {
+    this.costLoading = true;
+    this.costError = '';
+    this.admin.costSummary().subscribe({
+      next: (res) => {
+        this.cost = {
+          ...res,
+          services: [...res.services].sort((a, b) => b.amount - a.amount),
+        };
+        this.costLoading = false;
+      },
+      error: (err) => {
+        this.costError = this.errorMessage(err, 'Failed to load cost summary');
+        this.costLoading = false;
+      },
+    });
+  }
+
+  signOut(): void {
+    this.cognito.signOut().subscribe({
+      next: () => this.router.navigate(['/']),
+      error: () => this.router.navigate(['/']),
+    });
+  }
+
+  formatTime(iso: string): string {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }
+
+  formatMoney(amount: number, currency: string): string {
+    try {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(amount);
+    } catch {
+      return `${currency} ${amount.toFixed(2)}`;
+    }
+  }
+
+  formatRange(start: string, end: string): string {
+    return `${start} → ${end}`;
+  }
+
+  private todayIso(): string {
+    const d = new Date();
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+
+  private errorMessage(err: unknown, fallback: string): string {
+    if (err && typeof err === 'object' && 'status' in err) {
+      const status = (err as { status?: number }).status;
+      if (status === 403) {
+        return 'You no longer have admin access.';
+      }
+      if (status === 401) {
+        return 'Session expired — sign in again.';
+      }
+    }
+    if (err instanceof Error && err.message) {
+      return err.message;
+    }
+    return fallback;
+  }
+}

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,38 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { firstValueFrom } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+import { CognitoService } from '../services/cognito.service';
+
+/**
+ * Gate routes behind Cognito group membership in `admin`.
+ *
+ * Mirrors `cognitoAuthGuard`: waits for `isReady$` so we never read stale
+ * session state on first paint. Anonymous visitors and signed-in users
+ * without the `admin` group are bounced to `/` (silent — the link is not
+ * advertised on the landing page, so a soft redirect is the friendlier UX).
+ */
+export const adminGuard: CanActivateFn = async () => {
+  const cognito = inject(CognitoService);
+  const router = inject(Router);
+
+  await firstValueFrom(cognito.isReady$.pipe(filter((ready) => ready), take(1)));
+
+  if (!cognito.isAuthenticated()) {
+    return router.parseUrl('/');
+  }
+
+  try {
+    const session = await fetchAuthSession();
+    const groupsClaim = session.tokens?.idToken?.payload?.['cognito:groups'];
+    const groups = Array.isArray(groupsClaim) ? groupsClaim.map(String) : [];
+    if (groups.includes('admin')) {
+      return true;
+    }
+  } catch {
+    // Fall through to redirect.
+  }
+
+  return router.parseUrl('/');
+};

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -1,0 +1,70 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export type AdminEventType = 'signin' | 'signup';
+
+export interface AdminEvent {
+  eventId: string;
+  eventType: AdminEventType;
+  eventTime: string;
+  eventDate: string;
+  userId: string;
+  email: string;
+  identityProvider: string;
+  appClientId: string;
+}
+
+export interface EventsListRequest {
+  date?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface EventsListResponse {
+  date: string;
+  items: AdminEvent[];
+  nextCursor?: string;
+}
+
+export interface CostServiceLine {
+  service: string;
+  amount: number;
+  unit: string;
+}
+
+export interface CostSummaryRequest {
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface CostSummaryResponse {
+  start: string;
+  end: string;
+  total: number;
+  currency: string;
+  services: CostServiceLine[];
+  cached: boolean;
+}
+
+/**
+ * Wraps the admin endpoints exposed by the shared Xomware API. All endpoints
+ * are POST + JSON; the JWT is attached automatically by `jwtInterceptor` and
+ * the backend rejects (403) requests where the token's `cognito:groups`
+ * claim is missing the `admin` group.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminService {
+  private readonly baseUrl = `${environment.usersApiUrl}/admin`;
+
+  constructor(private http: HttpClient) {}
+
+  listEvents(body: EventsListRequest = {}): Observable<EventsListResponse> {
+    return this.http.post<EventsListResponse>(`${this.baseUrl}/events-list`, body);
+  }
+
+  costSummary(body: CostSummaryRequest = {}): Observable<CostSummaryResponse> {
+    return this.http.post<CostSummaryResponse>(`${this.baseUrl}/cost-summary`, body);
+  }
+}


### PR DESCRIPTION
## Summary
- New `/admin` route on xomware.com showing today's signin/signup events + month-to-date AWS cost.
- Gated by `adminGuard` checking the JWT's `cognito:groups` claim.
- Consumes the new admin API shipped in xomware-infrastructure#34.

## What changed
- **Guard** (`src/app/guards/admin.guard.ts`) — `CanActivateFn` reads `cognito:groups` from `fetchAuthSession()`'s id token; redirects to `/` if missing or not in `admin`.
- **Service** (`src/app/services/admin.service.ts`) — typed Observable wrappers for `POST /admin/events-list` and `POST /admin/cost-summary`. Uses `environment.usersApiUrl` so the existing `jwtInterceptor` attaches the Bearer token.
- **Page** (`src/app/components/admin/admin.component.{ts,html,scss}`) — two-card layout: events table (date picker + Load more) and MTD cost card (sorted services + total + cached pill). Uses existing `_variables.scss` cyan/dark tokens, mirrors command-center header style.
- **Routing/module** — adds the `/admin` route before the `**` wildcard; declares the component.

## Quality
- ✅ `npm run build` clean (single new component, ~840 lines)
- A11y: `role="alert"` on errors, visually-hidden label on date input, focus rings, ARIA on the events table
- Responsive: stacks under `lg`, hides provider column under `md`

## Depends on
- **Xomware/xomware-infrastructure#34** — backend table + endpoints

## Pre-merge checklist
1. Merge xomware-infrastructure#34 and apply (provisions table + lambdas + admin API).
2. Add yourself to the `admin` Cognito group:
   ```
   aws cognito-idp admin-add-user-to-group --user-pool-id <pool> --username <your-sub> --group-name admin
   ```
3. Then merge this PR.

## Deferred (intentional)
- **No nav link** to `/admin` from anywhere — admins know the URL, link isn't advertised.
- **No "access denied" toast** on redirect — would require a toast service that doesn't exist yet. Out of scope.
- **No date range picker on cost** — backend defaults to MTD; range UI is a follow-up if you want week/quarter views.
- **No Karma specs** — project has the harness but no existing guard/service specs to mirror.

## Test plan
- [ ] Hit `/admin` while signed out → redirected to `/`.
- [ ] Hit `/admin` while signed in but not in admin group → redirected to `/`.
- [ ] Add yourself to admin → page loads.
- [ ] Events table populates from today's signins.
- [ ] Date picker fetches a different day; "Load more" paginates via `nextCursor`.
- [ ] Cost card shows MTD total + sorted services; `cached` pill toggles after the second hit.