### PR TITLE
feat: public landing + /privacy page (OAuth verification prep)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,15 +13,20 @@ import { ForgotPasswordComponent } from './components/auth/forgot-password/forgo
 import { CallbackComponent } from './components/auth/callback/callback.component';
 import { ProfileComponent } from './components/auth/profile/profile.component';
 import { AdminComponent } from './components/admin/admin.component';
+import { PrivacyComponent } from './components/privacy/privacy.component';
 
 const routes: Routes = [
-  { path: '', component: LandingComponent, canActivate: [cognitoAuthGuard] },
+  // Landing is intentionally public so Google OAuth verification can confirm
+  // the home page renders without login. The landing component already
+  // tolerates `user: null` (no menu, just the public marketing view).
+  { path: '', component: LandingComponent },
+  { path: 'privacy', component: PrivacyComponent },
   { path: 'auth/sign-in', component: SignInComponent },
   { path: 'auth/sign-up', component: SignUpComponent },
   { path: 'auth/verify', component: VerifyComponent },
   { path: 'auth/forgot-password', component: ForgotPasswordComponent },
   { path: 'auth/callback', component: CallbackComponent },
-  { path: 'profile', component: ProfileComponent },
+  { path: 'profile', component: ProfileComponent, canActivate: [cognitoAuthGuard] },
   { path: 'command/login', component: AuthGateComponent },
   { path: 'command', component: CommandCenterComponent, canActivate: [AuthGuard] },
   { path: 'admin', component: AdminComponent, canActivate: [adminGuard] },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { ForgotPasswordComponent } from './components/auth/forgot-password/forgo
 import { CallbackComponent } from './components/auth/callback/callback.component';
 import { ProfileComponent } from './components/auth/profile/profile.component';
 import { AdminComponent } from './components/admin/admin.component';
+import { PrivacyComponent } from './components/privacy/privacy.component';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { AdminComponent } from './components/admin/admin.component';
     CallbackComponent,
     ProfileComponent,
     AdminComponent,
+    PrivacyComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -336,6 +336,10 @@
           <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="currentColor"/></svg>
           Report an issue
         </a>
+        <a routerLink="/privacy" class="footer-link">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z" fill="currentColor"/></svg>
+          Privacy
+        </a>
       </div>
       <div class="footer-bottom">
         <span class="footer-copy">&copy; 2026 Xomware. All rights reserved.</span>

--- a/src/app/components/privacy/privacy.component.html
+++ b/src/app/components/privacy/privacy.component.html
@@ -1,0 +1,74 @@
+<main class="privacy">
+  <header class="hero">
+    <a routerLink="/" class="back-link" aria-label="Back to xomware.com">&larr; Back</a>
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: {{ lastUpdated }}</p>
+  </header>
+
+  <section class="body">
+    <h2>What this is</h2>
+    <p>
+      Xomware is a personal portfolio of small apps run by Dominick Giordano (handle <strong>&#64;domgiordano</strong>).
+      This page describes what data Xomware collects when you use any app under <code>xomware.com</code> or any
+      sub-app such as <code>xomappetit.xomware.com</code>.
+    </p>
+
+    <h2>What we collect</h2>
+    <ul>
+      <li><strong>Email address</strong> &mdash; required to create an account.</li>
+      <li><strong>Handle</strong> (e.g. <code>&#64;domgiordano</code>) &mdash; chosen by you at sign-up.</li>
+      <li>
+        <strong>Display name and profile picture</strong> &mdash; if you sign in with Google, we store the name
+        and avatar Google returns. You can change either at any time on the profile page.
+      </li>
+      <li>
+        <strong>Sign-in / sign-up timestamps</strong> &mdash; we keep a small audit log so the operator (Dominick)
+        can see usage. Rows expire automatically after 90 days.
+      </li>
+      <li>
+        <strong>App-specific content you create</strong> &mdash; e.g. recipes you save in Xom App&eacute;tit, files
+        you edit, or any other data you enter into a Xomware app.
+      </li>
+    </ul>
+
+    <h2>How we store it</h2>
+    <p>
+      Account data lives in <strong>AWS Cognito</strong> (identity provider) and <strong>AWS DynamoDB</strong>
+      (profile + app data), encrypted at rest with AWS KMS. Avatars live in S3 behind CloudFront. Everything is
+      hosted in <code>us-east-1</code>.
+    </p>
+
+    <h2>Who we share it with</h2>
+    <p>
+      <strong>Nobody.</strong> Xomware does not sell, rent, or share your data. The only third parties that
+      touch your data are AWS (the hosting provider) and, if you choose Google sign-in, Google (purely to
+      authenticate you &mdash; we receive your email + display name + avatar URL and nothing else).
+    </p>
+
+    <h2>Cookies and tracking</h2>
+    <p>
+      Xomware uses session tokens issued by Cognito to keep you signed in. There is no third-party advertising,
+      no cross-site tracking, and no analytics that send your data outside Xomware.
+    </p>
+
+    <h2>Your rights</h2>
+    <p>
+      You can delete your account at any time from the profile page, which removes your row from the
+      identity pool and your profile data from DynamoDB. App-specific content (recipes, etc.) is
+      removed as part of account deletion. To request a copy of your data or ask any other question, email
+      <a href="mailto:dominickj.giordano&#64;gmail.com">dominickj.giordano&#64;gmail.com</a>.
+    </p>
+
+    <h2>Changes</h2>
+    <p>
+      If this policy changes, the &ldquo;Last updated&rdquo; date above will change with it. Material changes
+      will also be announced on the home page.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Dominick Giordano &mdash;
+      <a href="mailto:dominickj.giordano&#64;gmail.com">dominickj.giordano&#64;gmail.com</a>
+    </p>
+  </section>
+</main>

--- a/src/app/components/privacy/privacy.component.scss
+++ b/src/app/components/privacy/privacy.component.scss
@@ -1,0 +1,106 @@
+@import '../auth/_shared/auth-shell';
+
+.privacy {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 24px 96px;
+  color: var(--text-primary, #fafafa);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+
+  .hero {
+    margin-bottom: 32px;
+  }
+
+  .back-link {
+    display: inline-block;
+    color: #00b4d8;
+    text-decoration: none;
+    font-size: 14px;
+    margin-bottom: 24px;
+    transition: color 150ms ease;
+
+    &:hover,
+    &:focus-visible {
+      color: #48cae4;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #00b4d8;
+      outline-offset: 4px;
+      border-radius: 4px;
+    }
+  }
+
+  h1 {
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    margin: 0 0 8px;
+    background: linear-gradient(90deg, #00b4d8, #48cae4);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .updated {
+    color: #71717a;
+    font-size: 14px;
+    margin: 0;
+  }
+
+  .body {
+    h2 {
+      font-size: 20px;
+      font-weight: 700;
+      margin: 32px 0 12px;
+      color: #fafafa;
+    }
+
+    p,
+    ul {
+      color: #d4d4d8;
+      font-size: 15px;
+      margin: 0 0 12px;
+    }
+
+    ul {
+      padding-left: 22px;
+    }
+
+    li {
+      margin-bottom: 8px;
+    }
+
+    code {
+      background: #18181b;
+      border: 1px solid #27272a;
+      border-radius: 4px;
+      padding: 1px 6px;
+      font-size: 13px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: #00b4d8;
+    }
+
+    a {
+      color: #00b4d8;
+      text-decoration: none;
+
+      &:hover,
+      &:focus-visible {
+        color: #48cae4;
+        text-decoration: underline;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #00b4d8;
+        outline-offset: 2px;
+        border-radius: 2px;
+      }
+    }
+
+    strong {
+      color: #fafafa;
+    }
+  }
+}

--- a/src/app/components/privacy/privacy.component.ts
+++ b/src/app/components/privacy/privacy.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-privacy',
+  templateUrl: './privacy.component.html',
+  styleUrls: ['./privacy.component.scss'],
+})
+export class PrivacyComponent {
+  readonly lastUpdated = 'May 4, 2026';
+}


### PR DESCRIPTION
## Summary
Three small changes to unblock Google's OAuth consent-screen verification:

1. **Public landing** — remove `cognitoAuthGuard` from `path: ''`. Google's verifier needs the home URL to render without login. Landing already tolerates `user: null`. `/profile` now carries the guard explicitly (was inherited via landing before).
2. **`/privacy` route** — new `PrivacyComponent` with real policy text: what we collect (email, handle, display name, audit log), where it lives (Cognito + DDB + S3 in `us-east-1`), what's shared (nothing), how to delete an account, contact email.
3. **Footer Privacy link** on landing so the verifier finds the policy from the home page.

## Test plan
- [x] `npm run build` clean
- [ ] Visit `xomware.com` signed-out → see landing (not redirect to /sign-in)
- [ ] Click Privacy in footer → `/privacy` renders with content
- [ ] Re-run Google OAuth verification → all four issues resolved