### PR TITLE
feat(landing): hide app launcher behind auth

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -243,6 +243,25 @@
       <p class="section-subtitle">Products &amp; projects from the Xomware workshop.</p>
     </div>
 
+    <!-- Signed-out: lock the launcher behind auth, but keep the section
+         visible so anonymous visitors (and Google's OAuth verifier) still
+         see what Xomware is. -->
+    <div class="locked-launcher" *ngIf="!user">
+      <div class="locked-launcher-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1v2z" fill="currentColor"/>
+        </svg>
+      </div>
+      <h3 class="locked-launcher-title">Sign in to launch the suite</h3>
+      <p class="locked-launcher-copy">App access requires a Xomware account. Free, takes a minute.</p>
+      <div class="locked-launcher-actions">
+        <a routerLink="/auth/sign-in" class="locked-launcher-btn primary">Sign in</a>
+        <a routerLink="/auth/sign-up" class="locked-launcher-btn">Create account</a>
+      </div>
+    </div>
+
+    <!-- Signed-in: full launcher. -->
+    <ng-container *ngIf="user">
     <!-- Web Apps -->
     <h3 class="platform-heading">Web Apps</h3>
     <div class="cards-container">
@@ -315,6 +334,7 @@
         </a>
       </ng-container>
     </div>
+    </ng-container>
   </section>
 
   <!-- Footer -->

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -489,6 +489,85 @@
   z-index: 1;
 }
 
+.locked-launcher {
+  margin: $spacing-xl auto 0;
+  max-width: 480px;
+  padding: $spacing-2xl $spacing-xl;
+  background: rgba(24, 24, 27, 0.6);
+  border: 1px solid rgba(0, 180, 216, 0.18);
+  border-radius: 16px;
+  text-align: center;
+  backdrop-filter: blur(8px);
+
+  &-icon {
+    color: $brand-cyan;
+    margin-bottom: $spacing-md;
+    svg {
+      width: 32px;
+      height: 32px;
+    }
+  }
+
+  &-title {
+    font-size: 22px;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 $spacing-sm;
+  }
+
+  &-copy {
+    color: #a1a1aa;
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0 0 $spacing-lg;
+  }
+
+  &-actions {
+    display: flex;
+    gap: $spacing-md;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  &-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    text-decoration: none;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #d4d4d8;
+    background: transparent;
+    transition: all 150ms ease;
+
+    &:hover,
+    &:focus-visible {
+      border-color: $brand-cyan;
+      color: #fafafa;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $brand-cyan;
+      outline-offset: 2px;
+    }
+
+    &.primary {
+      background: linear-gradient(90deg, $brand-cyan, #48cae4);
+      border-color: transparent;
+      color: #0a0a0b;
+
+      &:hover,
+      &:focus-visible {
+        filter: brightness(1.05);
+        color: #0a0a0b;
+      }
+    }
+  }
+}
+
 .cards-container {
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
Anonymous visitors see the brand + 'Sign in to launch' CTA. Signed-in users see the full app launcher. Keeps the home page renderable for Google's OAuth verifier (which requires the URL to be unauth-accessible) while locking down the actual app menu so random visitors can't browse Dom's apps.