### PR TITLE
feat(landing): full anonymous gate — only brand + sign-in card when signed out

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -2,6 +2,25 @@
   <!-- Ambient GSAP blobs (fixed background layer) -->
   <app-monster></app-monster>
 
+  <!-- Signed-out gate. Anonymous visitors see only this — minimal brand
+       mark + sign-in CTA. Keeps the home page renderable for Google's
+       OAuth verifier without exposing any of Dom's content. -->
+  <main class="anon-gate" *ngIf="!user">
+    <div class="anon-gate-card">
+      <div class="anon-gate-mark">
+        <img src="assets/img/xomware-icon-transparent-background.png" alt="Xomware" />
+        <span class="anon-gate-wordmark">XOMWARE</span>
+      </div>
+      <p class="anon-gate-tagline">Sign in to continue.</p>
+      <div class="anon-gate-actions">
+        <a routerLink="/auth/sign-in" class="anon-gate-btn primary">Sign in</a>
+        <a routerLink="/auth/sign-up" class="anon-gate-btn">Create account</a>
+      </div>
+      <a routerLink="/privacy" class="anon-gate-link">Privacy policy</a>
+    </div>
+  </main>
+
+<ng-container *ngIf="user">
   <!-- Sticky Navigation -->
   <nav class="sticky-nav" [class.scrolled]="isScrolled">
     <div class="nav-inner">
@@ -243,25 +262,6 @@
       <p class="section-subtitle">Products &amp; projects from the Xomware workshop.</p>
     </div>
 
-    <!-- Signed-out: lock the launcher behind auth, but keep the section
-         visible so anonymous visitors (and Google's OAuth verifier) still
-         see what Xomware is. -->
-    <div class="locked-launcher" *ngIf="!user">
-      <div class="locked-launcher-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1v2z" fill="currentColor"/>
-        </svg>
-      </div>
-      <h3 class="locked-launcher-title">Sign in to launch the suite</h3>
-      <p class="locked-launcher-copy">App access requires a Xomware account. Free, takes a minute.</p>
-      <div class="locked-launcher-actions">
-        <a routerLink="/auth/sign-in" class="locked-launcher-btn primary">Sign in</a>
-        <a routerLink="/auth/sign-up" class="locked-launcher-btn">Create account</a>
-      </div>
-    </div>
-
-    <!-- Signed-in: full launcher. -->
-    <ng-container *ngIf="user">
     <!-- Web Apps -->
     <h3 class="platform-heading">Web Apps</h3>
     <div class="cards-container">
@@ -334,7 +334,6 @@
         </a>
       </ng-container>
     </div>
-    </ng-container>
   </section>
 
   <!-- Footer -->
@@ -366,4 +365,5 @@
       </div>
     </div>
   </footer>
+</ng-container>
 </div>

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -489,82 +489,117 @@
   z-index: 1;
 }
 
-.locked-launcher {
-  margin: $spacing-xl auto 0;
-  max-width: 480px;
-  padding: $spacing-2xl $spacing-xl;
-  background: rgba(24, 24, 27, 0.6);
-  border: 1px solid rgba(0, 180, 216, 0.18);
+// Anonymous gate — full-viewport centered card. Replaces the entire
+// landing for signed-out visitors. Brand mark + sign-in CTA only.
+.anon-gate {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-xl;
+}
+
+.anon-gate-card {
+  width: 100%;
+  max-width: 420px;
+  padding: $spacing-2xl;
+  background: rgba(24, 24, 27, 0.7);
+  border: 1px solid rgba(0, 180, 216, 0.2);
   border-radius: 16px;
   text-align: center;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(12px);
+}
 
-  &-icon {
-    color: $brand-cyan;
-    margin-bottom: $spacing-md;
-    svg {
-      width: 32px;
-      height: 32px;
-    }
+.anon-gate-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-md;
+
+  img {
+    width: 32px;
+    height: 32px;
   }
+}
 
-  &-title {
-    font-size: 22px;
-    font-weight: 700;
+.anon-gate-wordmark {
+  font-size: 22px;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  color: $brand-cyan;
+}
+
+.anon-gate-tagline {
+  color: #a1a1aa;
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 $spacing-lg;
+}
+
+.anon-gate-actions {
+  display: flex;
+  gap: $spacing-md;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: $spacing-lg;
+}
+
+.anon-gate-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #d4d4d8;
+  background: transparent;
+  transition: all 150ms ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: $brand-cyan;
     color: #fafafa;
-    margin: 0 0 $spacing-sm;
   }
 
-  &-copy {
-    color: #a1a1aa;
-    font-size: 14px;
-    line-height: 1.5;
-    margin: 0 0 $spacing-lg;
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
   }
 
-  &-actions {
-    display: flex;
-    gap: $spacing-md;
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-
-  &-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px 20px;
-    border-radius: 8px;
-    font-weight: 600;
-    font-size: 14px;
-    text-decoration: none;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    color: #d4d4d8;
-    background: transparent;
-    transition: all 150ms ease;
+  &.primary {
+    background: linear-gradient(90deg, $brand-cyan, #48cae4);
+    border-color: transparent;
+    color: #0a0a0b;
 
     &:hover,
     &:focus-visible {
-      border-color: $brand-cyan;
-      color: #fafafa;
-    }
-
-    &:focus-visible {
-      outline: 2px solid $brand-cyan;
-      outline-offset: 2px;
-    }
-
-    &.primary {
-      background: linear-gradient(90deg, $brand-cyan, #48cae4);
-      border-color: transparent;
+      filter: brightness(1.05);
       color: #0a0a0b;
-
-      &:hover,
-      &:focus-visible {
-        filter: brightness(1.05);
-        color: #0a0a0b;
-      }
     }
+  }
+}
+
+.anon-gate-link {
+  display: inline-block;
+  font-size: 12px;
+  color: #71717a;
+  text-decoration: none;
+  transition: color 150ms ease;
+
+  &:hover,
+  &:focus-visible {
+    color: $brand-cyan;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 


### PR DESCRIPTION
Anonymous visitors now see a single centered welcome card: brand mark, 'Sign in to continue', sign-in / create-account buttons, privacy link. Nothing else — no nav, no profile, no apps, no footer.

Signed-in users see the full landing (nav, hero, app launcher, footer) unchanged.

Google's OAuth verifier still gets a renderable home page with a visible privacy link, but anonymous visitors learn nothing about Dom's apps until they create an account.