### PR TITLE
fix(landing): better label fallback for federated users

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -80,7 +80,7 @@
             (click)="toggleUserMenu($event)"
             [attr.aria-expanded]="userMenuOpen"
             aria-haspopup="menu"
-            [attr.aria-label]="'Account menu for @' + userHandle"
+            [attr.aria-label]="'Account menu for ' + userLabel"
           >
             <span class="user-menu-avatar" [class.has-image]="profile?.avatarUrl">
               <img
@@ -92,7 +92,7 @@
                 {{ userInitial }}
               </span>
             </span>
-            <span class="user-menu-handle">&#64;{{ userHandle }}</span>
+            <span class="user-menu-handle">{{ userLabel }}</span>
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="report-menu-caret" [class.open]="userMenuOpen" aria-hidden="true">
               <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" fill="currentColor"/>
             </svg>

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -61,19 +61,26 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
       this.profile?.displayName ??
       this.profile?.preferredUsername ??
       this.user?.preferredUsername ??
+      this.profile?.email ??
       this.user?.username ??
       '?';
     return source.trim().charAt(0).toUpperCase() || '?';
   }
 
-  /** Display name + handle for the user menu trigger label. */
-  get userHandle(): string {
-    return (
-      this.profile?.preferredUsername ??
-      this.user?.preferredUsername ??
-      this.user?.username ??
-      ''
-    );
+  /**
+   * Label for the user menu trigger.
+   *
+   * Prefers `@handle` when a real preferredUsername is set, then displayName
+   * (no @), then the email-local-part. Falls back to the raw Cognito
+   * username only as a last resort — for federated users that's the ugly
+   * `Google_102793155679...` form which no one wants on screen.
+   */
+  get userLabel(): string {
+    const handle = this.profile?.preferredUsername || this.user?.preferredUsername;
+    if (handle) return `@${handle}`;
+    if (this.profile?.displayName) return this.profile.displayName;
+    if (this.profile?.email) return this.profile.email.split('@')[0];
+    return this.user?.username ?? '';
   }
 
   toggleUserMenu(event: Event): void {


### PR DESCRIPTION
Old chain ended at `user.username`, which for Google-federated users is `Google_102793155679...`. New chain: `@handle` → display name → email local-part. Drops the @ prefix when there's no real handle.

Pairs with xomware-infrastructure fix/federated-user-row-and-admin which JIT-populates displayName from Google's JWT claims.