### PR TITLE
fix: handle editing, admin link, federated user label, drop bogus stats

### DIFF
--- a/src/app/components/auth/profile/profile.component.html
+++ b/src/app/components/auth/profile/profile.component.html
@@ -25,7 +25,10 @@
           >{{ avatarInitial(profile) }}</span>
         </div>
 
-        <h1 class="profile-handle">&#64;{{ profile.preferredUsername }}</h1>
+        <h1 *ngIf="profile.preferredUsername" class="profile-handle">&#64;{{ profile.preferredUsername }}</h1>
+        <p *ngIf="!profile.preferredUsername" class="profile-handle profile-handle-empty">
+          No handle yet — <button type="button" class="link-button" (click)="openEdit()">choose one</button>
+        </p>
         <p class="profile-display-name">{{ fallbackDisplayName(profile) }}</p>
         <p class="profile-email" *ngIf="profile.email">{{ profile.email }}</p>
 
@@ -52,26 +55,6 @@
           </svg>
           {{ profile.profileVisibility === 'public' ? 'Public profile' : 'Private profile' }}
         </span>
-      </div>
-
-      <!-- Stats placeholders (v1) -->
-      <div class="profile-stats" role="list">
-        <div class="profile-stat" role="listitem">
-          <span class="stat-value">0</span>
-          <span class="stat-label">Apps</span>
-        </div>
-        <div class="profile-stat" role="listitem">
-          <span class="stat-value">0</span>
-          <span class="stat-label">Followers</span>
-        </div>
-        <div class="profile-stat" role="listitem">
-          <span class="stat-value">0</span>
-          <span class="stat-label">Following</span>
-        </div>
-        <div class="profile-stat" role="listitem">
-          <span class="stat-value">0</span>
-          <span class="stat-label">Posts</span>
-        </div>
       </div>
 
       <!-- Actions -->
@@ -168,6 +151,42 @@
           </label>
         </div>
         <span class="auth-hint">PNG, JPG, or WebP. Saved when you press Save.</span>
+      </div>
+
+      <!-- Handle -->
+      <div class="auth-field">
+        <label for="edit-handle" class="auth-label">Handle</label>
+        <div class="handle-input-wrapper">
+          <span class="handle-input-prefix" aria-hidden="true">&#64;</span>
+          <input
+            id="edit-handle"
+            type="text"
+            formControlName="preferredUsername"
+            class="auth-input handle-input"
+            [class.invalid]="fieldInvalid('preferredUsername')"
+            maxlength="20"
+            placeholder="hungry_chef"
+            autocomplete="username"
+            spellcheck="false"
+            autocapitalize="off"
+            [attr.aria-invalid]="fieldInvalid('preferredUsername') || null"
+            [attr.aria-describedby]="fieldInvalid('preferredUsername') ? 'edit-handle-error' : 'edit-handle-help'"
+          />
+        </div>
+        <span
+          *ngIf="!fieldInvalid('preferredUsername')"
+          id="edit-handle-help"
+          class="auth-help"
+        >
+          3–20 lowercase letters, numbers, or underscores. Must be unique.
+        </span>
+        <span
+          *ngIf="fieldInvalid('preferredUsername')"
+          id="edit-handle-error"
+          class="auth-error-field"
+        >
+          {{ handleErrorMessage }}
+        </span>
       </div>
 
       <!-- Display name -->

--- a/src/app/components/auth/profile/profile.component.ts
+++ b/src/app/components/auth/profile/profile.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { CognitoService } from '../../../services/cognito.service';
@@ -12,6 +12,21 @@ import {
 
 const ALLOWED_AVATAR_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
 const MAX_DISPLAY_NAME = 50;
+const HANDLE_REGEX = /^[a-z0-9_]{3,20}$/;
+const RESERVED_HANDLES = new Set([
+  'admin', 'system', 'xomware', 'xomappetit', 'support',
+  'chef', 'diner', 'help', 'about', 'privacy', 'terms',
+  'api', 'auth', 'profile', 'login', 'signin', 'signup',
+  'me', 'you', 'user', 'users',
+]);
+
+function handleValidator(control: AbstractControl): ValidationErrors | null {
+  const value = (control.value as string | null)?.trim().toLowerCase() ?? '';
+  if (!value) return null; // optional — empty is allowed
+  if (!HANDLE_REGEX.test(value)) return { pattern: true };
+  if (RESERVED_HANDLES.has(value)) return { reserved: true };
+  return null;
+}
 
 @Component({
   selector: 'app-profile',
@@ -42,6 +57,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
   ) {
     this.profile$ = this.profileService.profile$;
     this.editForm = this.fb.group({
+      preferredUsername: ['', [handleValidator]],
       displayName: [
         '',
         [
@@ -52,6 +68,15 @@ export class ProfileComponent implements OnInit, OnDestroy {
       ],
       profileVisibility: ['public' as ProfileVisibility, Validators.required],
     });
+  }
+
+  get handleErrorMessage(): string {
+    const ctrl = this.editForm.get('preferredUsername');
+    if (!ctrl) return '';
+    if (ctrl.hasError('pattern')) return '3–20 lowercase letters, numbers, or underscores.';
+    if (ctrl.hasError('reserved')) return 'That handle is reserved. Pick another.';
+    if (ctrl.hasError('taken')) return 'That handle is already taken.';
+    return 'Invalid handle.';
   }
 
   ngOnInit(): void {
@@ -91,6 +116,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.errorMessage = '';
     this.pendingAvatarUrl = null;
     this.editForm.reset({
+      preferredUsername: this.currentProfile.preferredUsername ?? '',
       displayName: this.currentProfile.displayName ?? '',
       profileVisibility: this.currentProfile.profileVisibility ?? 'public',
     });
@@ -104,7 +130,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.errorMessage = '';
   }
 
-  fieldInvalid(name: 'displayName'): boolean {
+  fieldInvalid(name: 'displayName' | 'preferredUsername'): boolean {
     const ctrl = this.editForm.get(name);
     return !!ctrl && ctrl.invalid && (ctrl.dirty || ctrl.touched);
   }
@@ -144,7 +170,8 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.saving = true;
     this.errorMessage = '';
 
-    const { displayName, profileVisibility } = this.editForm.value as {
+    const { preferredUsername, displayName, profileVisibility } = this.editForm.value as {
+      preferredUsername: string;
       displayName: string;
       profileVisibility: ProfileVisibility;
     };
@@ -153,6 +180,10 @@ export class ProfileComponent implements OnInit, OnDestroy {
       displayName: displayName.trim(),
       profileVisibility,
     };
+    const newHandle = (preferredUsername || '').trim().toLowerCase();
+    if (newHandle && newHandle !== this.currentProfile?.preferredUsername) {
+      payload['preferredUsername'] = newHandle;
+    }
     if (this.pendingAvatarUrl) {
       payload['avatarUrl'] = this.pendingAvatarUrl;
     }
@@ -164,9 +195,16 @@ export class ProfileComponent implements OnInit, OnDestroy {
         this.editOpen = false;
         this.pendingAvatarUrl = null;
       },
-      error: () => {
+      error: (err: { status?: number; error?: { error?: string } }) => {
         this.saving = false;
-        this.errorMessage = 'Could not save changes. Please try again.';
+        if (err?.status === 409 || err?.error?.error === 'handle_taken') {
+          // Surface uniqueness collision on the field itself.
+          this.editForm.get('preferredUsername')?.setErrors({ taken: true });
+          this.editForm.get('preferredUsername')?.markAsTouched();
+          this.errorMessage = '';
+        } else {
+          this.errorMessage = 'Could not save changes. Please try again.';
+        }
       },
     });
   }

--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -101,6 +101,9 @@
             <a routerLink="/profile" role="menuitem" class="report-menu-item" (click)="closeUserMenu()">
               <span class="report-menu-label">Profile</span>
             </a>
+            <a *ngIf="isAdmin" routerLink="/admin" role="menuitem" class="report-menu-item" (click)="closeUserMenu()">
+              <span class="report-menu-label">Admin portal</span>
+            </a>
             <button type="button" role="menuitem" class="report-menu-item user-menu-signout" (click)="signOut()">
               <span class="report-menu-label">Sign out</span>
             </button>

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -83,6 +83,11 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
     return this.user?.username ?? '';
   }
 
+  /** True when the signed-in user is in the Cognito `admin` group. */
+  get isAdmin(): boolean {
+    return (this.user?.groups ?? []).includes('admin');
+  }
+
   toggleUserMenu(event: Event): void {
     event.stopPropagation();
     this.userMenuOpen = !this.userMenuOpen;

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -38,6 +38,7 @@ export interface MinimalUser {
 
 /** Whitelist of fields the user can self-edit via `POST /users/edit`. */
 export interface EditableFields {
+  preferredUsername: string;
   displayName: string;
   profileVisibility: ProfileVisibility;
   avatarUrl: string | null;

--- a/src/app/services/cognito.service.ts
+++ b/src/app/services/cognito.service.ts
@@ -19,6 +19,8 @@ export interface XomUser {
   username: string;
   preferredUsername?: string;
   email?: string;
+  /** Cognito groups (e.g. `['admin']`). Empty for unprivileged users. */
+  groups: string[];
 }
 
 /**
@@ -188,12 +190,21 @@ export class CognitoService implements OnDestroy {
       const current = await getCurrentUser();
       const session = await fetchAuthSession();
       const claims = session.tokens?.idToken?.payload ?? {};
+      // Don't fall back to `current.username` for preferredUsername — for
+      // federated users that's the ugly Google_<id> form, and templates
+      // that prefix `@` on this value end up rendering `@Google_...`.
+      // Leave undefined when the user hasn't picked a real handle yet.
+      const preferredUsername =
+        typeof claims['preferred_username'] === 'string'
+          ? (claims['preferred_username'] as string)
+          : undefined;
+      const groups = (claims['cognito:groups'] as string[] | undefined) ?? [];
       const user: XomUser = {
         userId: current.userId,
         username: current.username,
-        preferredUsername:
-          (claims['preferred_username'] as string | undefined) ?? current.username,
+        preferredUsername,
         email: claims['email'] as string | undefined,
+        groups,
       };
       this.userSubject.next(user);
       return user;


### PR DESCRIPTION
## Summary
Five issues from first Google sign-in:

1. **Federated user label fix**: `cognito.service.refreshUser` was falling back to `current.username` for `preferredUsername` — for federated users that's `Google_<id>`, which got rendered as `@Google_102793...` in the user menu. Leave `preferredUsername` undefined when the JWT lacks the claim.
2. **Admin link**: New 'Admin portal' menu item visible only to users in the Cognito `admin` group (`cognito:groups` claim). Adds `groups` to `XomUser`.
3. **Profile page — empty handle**: Hide the empty `@` line; show 'No handle yet — choose one' that opens the edit modal.
4. **Profile page — stats**: Drop the Apps / Followers / Following / Posts block. Doesn't apply to the org-level identity hub.
5. **Profile edit — handle field**: User can now set/change their handle. Client-side validates format + reserved words; backend does the uniqueness check (409 → 'handle_taken' surfaced on the field).

## Pairs with
xomware-infrastructure#TBD (users-edit lambda accepts preferredUsername)