### PR TITLE
feat(profile): avatar picker — stock colors, recent uploads, device

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,8 @@ import { CallbackComponent } from './components/auth/callback/callback.component
 import { ProfileComponent } from './components/auth/profile/profile.component';
 import { AdminComponent } from './components/admin/admin.component';
 import { PrivacyComponent } from './components/privacy/privacy.component';
+import { AvatarPickerComponent } from './components/avatar-picker/avatar-picker.component';
+import { StockAvatarComponent } from './components/avatar-picker/stock-avatar.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +39,8 @@ import { PrivacyComponent } from './components/privacy/privacy.component';
     ProfileComponent,
     AdminComponent,
     PrivacyComponent,
+    AvatarPickerComponent,
+    StockAvatarComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/auth/profile/profile.component.html
+++ b/src/app/components/auth/profile/profile.component.html
@@ -10,19 +10,19 @@
       <div class="profile-hero">
         <div
           class="profile-avatar-large"
-          [class.has-image]="profile.avatarUrl || pendingAvatarUrl"
+          [class.has-image]="profile.avatarUrl"
           [attr.aria-label]="'Avatar for ' + fallbackDisplayName(profile)"
         >
           <img
-            *ngIf="profile.avatarUrl || pendingAvatarUrl"
-            [src]="pendingAvatarUrl || profile.avatarUrl"
+            *ngIf="profile.avatarUrl"
+            [src]="profile.avatarUrl"
             [alt]="fallbackDisplayName(profile) + ' avatar'"
           />
-          <span
-            *ngIf="!profile.avatarUrl && !pendingAvatarUrl"
-            class="profile-avatar-initial"
-            aria-hidden="true"
-          >{{ avatarInitial(profile) }}</span>
+          <app-stock-avatar
+            *ngIf="!profile.avatarUrl"
+            [color]="profile.avatarStockColor || '#00b4d8'"
+            [size]="120"
+          ></app-stock-avatar>
         </div>
 
         <h1 *ngIf="profile.preferredUsername" class="profile-handle">&#64;{{ profile.preferredUsername }}</h1>
@@ -114,43 +114,16 @@
       class="auth-form edit-modal-form"
       novalidate
     >
-      <!-- Avatar upload -->
-      <div class="auth-field">
+      <!-- Avatar picker — stock colors, recent uploads, device upload -->
+      <div class="auth-field" *ngIf="profile$ | async as p">
         <span class="auth-label">Avatar</span>
-        <div class="avatar-upload-row">
-          <ng-container *ngIf="profile$ | async as p">
-            <div
-              class="profile-avatar-medium"
-              [class.has-image]="pendingAvatarUrl || p.avatarUrl"
-            >
-              <img
-                *ngIf="pendingAvatarUrl || p.avatarUrl"
-                [src]="pendingAvatarUrl || p.avatarUrl"
-                alt=""
-              />
-              <span
-                *ngIf="!pendingAvatarUrl && !p.avatarUrl"
-                class="profile-avatar-initial"
-                aria-hidden="true"
-              >{{ avatarInitial(p) }}</span>
-            </div>
-          </ng-container>
-
-          <label class="auth-btn-ghost avatar-upload-button">
-            <span *ngIf="!uploadingAvatar">
-              {{ pendingAvatarUrl ? 'Choose a different image' : 'Upload new avatar' }}
-            </span>
-            <span *ngIf="uploadingAvatar" class="spinner" aria-label="Uploading"></span>
-            <input
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              (change)="onAvatarFileSelected($event)"
-              [disabled]="uploadingAvatar || saving"
-              hidden
-            />
-          </label>
-        </div>
-        <span class="auth-hint">PNG, JPG, or WebP. Saved when you press Save.</span>
+        <app-avatar-picker
+          [avatarUrl]="p.avatarUrl"
+          [stockColor]="p.avatarStockColor"
+          [history]="p.avatarHistory || []"
+          [pending]="pendingAvatarChoice"
+          (choiceChange)="onAvatarChoice($event)"
+        ></app-avatar-picker>
       </div>
 
       <!-- Handle -->
@@ -251,12 +224,12 @@
           type="button"
           class="auth-btn-ghost"
           (click)="closeEdit()"
-          [disabled]="saving || uploadingAvatar"
+          [disabled]="saving"
         >Cancel</button>
         <button
           type="submit"
           class="auth-btn"
-          [disabled]="saving || uploadingAvatar"
+          [disabled]="saving"
         >
           <span *ngIf="!saving">Save</span>
           <span *ngIf="saving" class="spinner" aria-label="Saving"></span>

--- a/src/app/components/auth/profile/profile.component.ts
+++ b/src/app/components/auth/profile/profile.component.ts
@@ -9,8 +9,8 @@ import {
   ProfileVisibility,
   UserProfile,
 } from '../../../models/user.model';
+import { AvatarChoice } from '../../avatar-picker/avatar-picker.component';
 
-const ALLOWED_AVATAR_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
 const MAX_DISPLAY_NAME = 50;
 const HANDLE_REGEX = /^[a-z0-9_]{3,20}$/;
 const RESERVED_HANDLES = new Set([
@@ -39,11 +39,10 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
   editOpen = false;
   saving = false;
-  uploadingAvatar = false;
   errorMessage = '';
 
-  /** Live-preview URL while a freshly-uploaded avatar isn't yet persisted via `edit()`. */
-  pendingAvatarUrl: string | null = null;
+  /** Pending avatar choice (photo URL or stock color) the user hasn't saved yet. */
+  pendingAvatarChoice: AvatarChoice | null = null;
 
   private profileSub?: Subscription;
   private currentProfile: UserProfile | null = null;
@@ -114,7 +113,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
   openEdit(): void {
     if (!this.currentProfile) return;
     this.errorMessage = '';
-    this.pendingAvatarUrl = null;
+    this.pendingAvatarChoice = null;
     this.editForm.reset({
       preferredUsername: this.currentProfile.preferredUsername ?? '',
       displayName: this.currentProfile.displayName ?? '',
@@ -124,9 +123,9 @@ export class ProfileComponent implements OnInit, OnDestroy {
   }
 
   closeEdit(): void {
-    if (this.saving || this.uploadingAvatar) return;
+    if (this.saving) return;
     this.editOpen = false;
-    this.pendingAvatarUrl = null;
+    this.pendingAvatarChoice = null;
     this.errorMessage = '';
   }
 
@@ -135,31 +134,8 @@ export class ProfileComponent implements OnInit, OnDestroy {
     return !!ctrl && ctrl.invalid && (ctrl.dirty || ctrl.touched);
   }
 
-  onAvatarFileSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) return;
-
-    if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
-      this.errorMessage = 'Avatar must be a PNG, JPG, or WebP image.';
-      input.value = '';
-      return;
-    }
-
-    this.errorMessage = '';
-    this.uploadingAvatar = true;
-    this.users.uploadAvatar(file).subscribe({
-      next: (finalUrl) => {
-        this.pendingAvatarUrl = finalUrl;
-        this.uploadingAvatar = false;
-        input.value = '';
-      },
-      error: () => {
-        this.uploadingAvatar = false;
-        this.errorMessage = 'Avatar upload failed. Please try again.';
-        input.value = '';
-      },
-    });
+  onAvatarChoice(choice: AvatarChoice): void {
+    this.pendingAvatarChoice = choice;
   }
 
   onSubmit(): void {
@@ -184,8 +160,12 @@ export class ProfileComponent implements OnInit, OnDestroy {
     if (newHandle && newHandle !== this.currentProfile?.preferredUsername) {
       payload['preferredUsername'] = newHandle;
     }
-    if (this.pendingAvatarUrl) {
-      payload['avatarUrl'] = this.pendingAvatarUrl;
+    if (this.pendingAvatarChoice?.kind === 'photo') {
+      payload['avatarUrl'] = this.pendingAvatarChoice.url;
+      payload['avatarStockColor'] = null;
+    } else if (this.pendingAvatarChoice?.kind === 'stock') {
+      payload['avatarStockColor'] = this.pendingAvatarChoice.color;
+      payload['avatarUrl'] = null;
     }
 
     this.users.edit(payload).subscribe({
@@ -193,7 +173,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
         this.profileService.setProfile(updated);
         this.saving = false;
         this.editOpen = false;
-        this.pendingAvatarUrl = null;
+        this.pendingAvatarChoice = null;
       },
       error: (err: { status?: number; error?: { error?: string } }) => {
         this.saving = false;

--- a/src/app/components/avatar-picker/avatar-picker.component.html
+++ b/src/app/components/avatar-picker/avatar-picker.component.html
@@ -1,0 +1,67 @@
+<div class="picker">
+  <!-- Preview -->
+  <div class="preview-row">
+    <div class="preview-circle" [class.has-photo]="activePhoto">
+      <img *ngIf="activePhoto" [src]="activePhoto" alt="" />
+      <app-stock-avatar
+        *ngIf="!activePhoto"
+        [color]="previewColor"
+        [size]="88"
+      ></app-stock-avatar>
+    </div>
+    <div class="preview-meta">
+      <p class="preview-label">{{ previewLabel }}</p>
+      <p class="preview-hint">Pick a color, reuse a past photo, or upload a new one.</p>
+    </div>
+  </div>
+
+  <!-- Upload -->
+  <div class="upload-row">
+    <label class="upload-button" [class.disabled]="uploading">
+      {{ uploading ? 'Uploading…' : '+ Upload from device' }}
+      <input
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        (change)="onFileSelected($event)"
+        [disabled]="uploading"
+      />
+    </label>
+    <p *ngIf="uploadError" role="alert" class="upload-error">{{ uploadError }}</p>
+  </div>
+
+  <!-- Stock swatches -->
+  <div class="section">
+    <div class="section-label">Stock</div>
+    <div class="swatch-grid">
+      <button
+        *ngFor="let sw of swatches"
+        type="button"
+        class="swatch"
+        [class.selected]="isStockSelected(sw.hex)"
+        [attr.aria-label]="'Stock avatar ' + sw.label"
+        [attr.aria-pressed]="isStockSelected(sw.hex)"
+        (click)="pickStock(sw.hex)"
+      >
+        <app-stock-avatar [color]="sw.hex" [size]="44"></app-stock-avatar>
+      </button>
+    </div>
+  </div>
+
+  <!-- Recent uploads -->
+  <div *ngIf="history.length > 0" class="section">
+    <div class="section-label">Recent</div>
+    <div class="history-grid">
+      <button
+        *ngFor="let url of history"
+        type="button"
+        class="history-tile"
+        [class.selected]="isPhotoSelected(url)"
+        aria-label="Reuse this photo"
+        [attr.aria-pressed]="isPhotoSelected(url)"
+        (click)="pickPhoto(url)"
+      >
+        <img [src]="url" alt="" />
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/avatar-picker/avatar-picker.component.scss
+++ b/src/app/components/avatar-picker/avatar-picker.component.scss
@@ -1,0 +1,143 @@
+@import '../auth/_shared/auth-shell';
+
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preview-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.preview-circle {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  border: 1px solid #3f3f46;
+  background: #18181b;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.preview-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.preview-label {
+  margin: 0;
+  font-size: 14px;
+  color: #d4d4d8;
+}
+
+.preview-hint {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #71717a;
+}
+
+.upload-button {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: #18181b;
+  border: 1px solid #27272a;
+  color: #fafafa;
+  font-size: 13px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 150ms ease;
+
+  &:hover:not(.disabled) {
+    background: #27272a;
+    border-color: rgba(0, 180, 216, 0.5);
+  }
+
+  &.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  input {
+    display: none;
+  }
+}
+
+.upload-error {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #ff9598;
+}
+
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #71717a;
+  margin-bottom: 8px;
+}
+
+.swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+
+  @media (min-width: 480px) {
+    grid-template-columns: repeat(8, 1fr);
+  }
+}
+
+.swatch,
+.history-tile {
+  position: relative;
+  height: 56px;
+  width: 100%;
+  border-radius: 8px;
+  background: #18181b;
+  border: 1px solid #27272a;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  overflow: hidden;
+  padding: 0;
+  transition: all 150ms ease;
+
+  &:hover {
+    border-color: #52525b;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(0, 180, 216, 0.5);
+  }
+
+  &.selected {
+    border-color: #00b4d8;
+    box-shadow: 0 0 0 1px rgba(0, 180, 216, 0.4);
+  }
+}
+
+.history-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+}
+
+.history-tile img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/src/app/components/avatar-picker/avatar-picker.component.ts
+++ b/src/app/components/avatar-picker/avatar-picker.component.ts
@@ -1,0 +1,87 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { AVATAR_SWATCHES, APP_DEFAULT_AVATAR_COLOR } from '../../models/avatar-swatches';
+import { UsersService } from '../../services/users.service';
+
+export type AvatarChoice =
+  | { kind: 'photo'; url: string }
+  | { kind: 'stock'; color: string };
+
+@Component({
+  selector: 'app-avatar-picker',
+  templateUrl: './avatar-picker.component.html',
+  styleUrls: ['./avatar-picker.component.scss'],
+})
+export class AvatarPickerComponent {
+  @Input() avatarUrl: string | null = null;
+  @Input() stockColor: string | null = null;
+  @Input() history: string[] = [];
+  /** Pending in-flight choice the parent hasn't saved yet. */
+  @Input() pending: AvatarChoice | null = null;
+  @Output() choiceChange = new EventEmitter<AvatarChoice>();
+
+  readonly swatches = AVATAR_SWATCHES;
+  readonly defaultColor = APP_DEFAULT_AVATAR_COLOR;
+
+  uploading = false;
+  uploadError: string | null = null;
+
+  constructor(private users: UsersService) {}
+
+  /** What to render in the preview right now: pending wins over saved. */
+  get activePhoto(): string | null {
+    if (this.pending?.kind === 'photo') return this.pending.url;
+    if (this.pending) return null;
+    return this.avatarUrl;
+  }
+
+  get activeStock(): string | null {
+    if (this.pending?.kind === 'stock') return this.pending.color;
+    if (this.pending) return null;
+    return this.stockColor;
+  }
+
+  get previewColor(): string {
+    return this.activeStock || this.defaultColor;
+  }
+
+  get previewLabel(): string {
+    if (this.activePhoto) return 'Custom photo';
+    if (this.activeStock) return 'Stock avatar';
+    return 'Default avatar';
+  }
+
+  pickStock(color: string): void {
+    this.choiceChange.emit({ kind: 'stock', color });
+  }
+
+  pickPhoto(url: string): void {
+    this.choiceChange.emit({ kind: 'photo', url });
+  }
+
+  isStockSelected(hex: string): boolean {
+    return this.activeStock === hex && !this.activePhoto;
+  }
+
+  isPhotoSelected(url: string): boolean {
+    return this.activePhoto === url;
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+    this.uploadError = null;
+    this.uploading = true;
+    this.users.uploadAvatar(file).subscribe({
+      next: (url: string) => {
+        this.uploading = false;
+        this.choiceChange.emit({ kind: 'photo', url });
+      },
+      error: (err: Error) => {
+        this.uploading = false;
+        this.uploadError = err?.message || 'Upload failed.';
+      },
+    });
+  }
+}

--- a/src/app/components/avatar-picker/stock-avatar.component.ts
+++ b/src/app/components/avatar-picker/stock-avatar.component.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+/**
+ * Inline-SVG version of /assets/img/xomware-user.svg so the eyes/mouth
+ * (which use `currentColor`) inherit the chosen color from the parent.
+ * External <img> SVGs ignore page CSS, so we have to inline the markup.
+ */
+@Component({
+  selector: 'app-stock-avatar',
+  template: `
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 500 500"
+      [attr.width]="size"
+      [attr.height]="size"
+      [style.color]="color"
+      [style.width.px]="size"
+      [style.height.px]="size"
+      aria-hidden="true"
+    >
+      <g fill="#000">
+        <circle cx="250" cy="170" r="115" />
+        <path
+          d="M 250,300 C 130,300 60,365 60,445 L 60,500 L 440,500 L 440,445 C 440,365 370,300 250,300 Z"
+        />
+      </g>
+      <rect
+        x="155" y="146" width="80" height="18" rx="9"
+        fill="currentColor" transform="rotate(45 195 155)"
+      />
+      <rect
+        x="155" y="146" width="80" height="18" rx="9"
+        fill="currentColor" transform="rotate(-45 195 155)"
+      />
+      <rect
+        x="265" y="146" width="80" height="18" rx="9"
+        fill="currentColor" transform="rotate(45 305 155)"
+      />
+      <rect
+        x="265" y="146" width="80" height="18" rx="9"
+        fill="currentColor" transform="rotate(-45 305 155)"
+      />
+      <rect x="185" y="221" width="130" height="18" rx="9" fill="currentColor" />
+    </svg>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StockAvatarComponent {
+  /** Hex color for the X eyes + mouth. Silhouette stays black. */
+  @Input() color = '#00b4d8';
+  /** Render size in px (square). */
+  @Input() size = 64;
+}

--- a/src/app/models/avatar-swatches.ts
+++ b/src/app/models/avatar-swatches.ts
@@ -1,0 +1,24 @@
+/**
+ * Stock-avatar color swatches. Each swatch maps to one Xomware app's
+ * primary brand color. Users pick a swatch in the EditProfileModal and
+ * the stock SVG (assets/img/xomware-user.svg) is tinted to that hex via
+ * CSS color.
+ */
+export interface AvatarSwatch {
+  hex: string;
+  label: string;
+}
+
+export const AVATAR_SWATCHES: readonly AvatarSwatch[] = [
+  { hex: '#00b4d8', label: 'Cyan' },         // Xomware
+  { hex: '#ff6b6b', label: 'Coral' },        // Xom Appétit
+  { hex: '#9c0abf', label: 'Purple' },       // Xomify
+  { hex: '#ff6b35', label: 'Orange' },       // XomCloud
+  { hex: '#00ffab', label: 'Mint' },         // Xomper
+  { hex: '#34C759', label: 'Green' },        // XomFit
+  { hex: '#C8102E', label: 'Crimson' },      // Sun God Derby
+  { hex: '#FFB800', label: 'Amber' },        // Float
+];
+
+/** App-default for xomware.com — highlighted swatch when no stock color set. */
+export const APP_DEFAULT_AVATAR_COLOR = '#00b4d8';

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -18,6 +18,10 @@ export interface UserProfile {
   preferredUsername: string;
   displayName: string;
   avatarUrl: string | null;
+  /** Hex color (`#rrggbb`) for the stock SVG avatar; null when using uploaded photo or app default. */
+  avatarStockColor: string | null;
+  /** Recently-used avatar URLs (most recent first, capped at 6). */
+  avatarHistory: string[];
   profileVisibility: ProfileVisibility;
   bio?: string | null;
   createdAt?: string;
@@ -33,6 +37,7 @@ export interface MinimalUser {
   preferredUsername: string;
   displayName: string;
   avatarUrl: string | null;
+  avatarStockColor: string | null;
   profileVisibility: ProfileVisibility;
 }
 
@@ -42,6 +47,8 @@ export interface EditableFields {
   displayName: string;
   profileVisibility: ProfileVisibility;
   avatarUrl: string | null;
+  /** Hex `#rrggbb` for the stock SVG. Mutually exclusive with avatarUrl. */
+  avatarStockColor: string | null;
   bio: string | null;
 }
 


### PR DESCRIPTION
Mirrors xomappetit-frontend's avatar picker for parity. Same backend (xomware-users), same shared SVG asset, same 8-color swatch palette.

EditProfileModal section in the profile flow gets a new `<app-avatar-picker>` component with:
1. Stock — 8 colored variants of the X-eyes brand mark
2. Recent — past uploaded URLs from `avatarHistory`
3. Upload from device — presigned PUT

Profile hero (outside the modal) shows the stock SVG tinted to `avatarStockColor || #00b4d8` when no photo is uploaded.

Pairs with **xomware-infrastructure#42**.