### PR TITLE
Flip /music Radar and Wrapped tabs to live

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment = {
   musicProfileUserId: '12146721999',
   musicSurfaces: {
     now: 'live',
-    radar: 'coming-soon',
-    wrapped: 'coming-soon',
+    radar: 'live',
+    wrapped: 'live',
   } as { now: 'live' | 'mock' | 'coming-soon'; radar: 'live' | 'mock' | 'coming-soon'; wrapped: 'live' | 'mock' | 'coming-soon' },
 };


### PR DESCRIPTION
Backend endpoints for Release Radar (#187) and Wrapped (#188) are deployed and curl-validated with real data. Flips `musicSurfaces.radar`/`.wrapped` from `coming-soon` to `live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)