### PR TITLE
Music page cohesion: backdrop, ticker rework, restyled toggle

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -201,7 +201,7 @@
     </div>
   </section>
 
-  <!-- Music ticker on landing — fed from landing's own MusicService fetch -->
+  <!-- Music ticker — footer strip, very bottom of page before footer -->
   <div class="landing-ticker-wrap" *ngIf="landingTickerProfile">
     <app-music-ticker [profile]="landingTickerProfile" [nowPlaying]="null"></app-music-ticker>
   </div>

--- a/src/app/components/music-ticker/music-ticker.component.html
+++ b/src/app/components/music-ticker/music-ticker.component.html
@@ -1,56 +1,120 @@
 <div class="ticker-wrap" aria-label="Scrolling music highlights" role="region">
-  <!-- Now-playing slot (v2 — null in v1) -->
-  <div class="now-playing-slot" *ngIf="nowPlaying" aria-label="Now playing">
-    <ng-content></ng-content>
-  </div>
-
-  <div class="ticker-track" *ngIf="items.length > 0" aria-hidden="true">
-    <!-- Two identical rows make a seamless loop -->
+  <div class="ticker-track" *ngIf="segments.length > 0" aria-hidden="true">
+    <!-- Primary row — these anchors ARE accessible (tabindex="-1" since
+         they're inside aria-hidden; the aria-hidden is on ticker-track,
+         not the outer region, so AT skips the marquee without losing the landmark) -->
     <div class="ticker-row ticker-row--a">
-      <a
-        *ngFor="let item of items"
-        [href]="item.url"
-        target="_blank"
-        rel="noopener"
-        class="ticker-item"
-        [class.ticker-item--track]="item.type === 'track'"
-        [class.ticker-item--artist]="item.type === 'artist'"
-        tabindex="-1"
-      >
-        <img
-          [src]="item.imageUrl"
-          [alt]="item.type === 'track' ? item.label + ' album art' : item.label + ' artist photo'"
-          class="ticker-item-img"
-          loading="lazy"
-        />
-        <span class="ticker-item-text">
-          <span class="ticker-item-label">{{ item.label }}</span>
-          <span class="ticker-item-sub">{{ item.sub }}</span>
+      <ng-container *ngFor="let seg of segments">
+
+        <!-- Category divider / label -->
+        <span class="ticker-divider" *ngIf="isDivider(seg)">
+          <span class="ticker-divider-timeframe">{{ seg.timeframe }}</span>
+          <span class="ticker-divider-sep" aria-hidden="true">·</span>
+          <span class="ticker-divider-label">{{ seg.label }}</span>
         </span>
-      </a>
+
+        <!-- Track / artist / genre item -->
+        <a
+          *ngIf="isItem(seg)"
+          [href]="seg.url"
+          target="_blank"
+          rel="noopener"
+          class="ticker-item"
+          [class.ticker-item--track]="seg.type === 'track'"
+          [class.ticker-item--artist]="seg.type === 'artist'"
+          [class.ticker-item--genre]="seg.type === 'genre'"
+          tabindex="-1"
+        >
+          <span class="ticker-item-img-wrap">
+            <img
+              *ngIf="seg.imageUrl"
+              [src]="seg.imageUrl"
+              [alt]="seg.type === 'track' ? seg.label + ' album art' : seg.label"
+              class="ticker-item-img"
+              loading="lazy"
+            />
+            <span *ngIf="!seg.imageUrl" class="ticker-item-genre-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/></svg>
+            </span>
+          </span>
+          <span class="ticker-item-text">
+            <span class="ticker-item-label">{{ seg.label }}</span>
+            <span class="ticker-item-sub">{{ seg.sub }}</span>
+          </span>
+          <span class="ticker-dot" aria-hidden="true">·</span>
+        </a>
+
+        <!-- Powered by Xomify badge -->
+        <a
+          *ngIf="isBadge(seg)"
+          [href]="xomifyUrl"
+          target="_blank"
+          rel="noopener"
+          class="ticker-badge"
+          tabindex="-1"
+        >
+          <img [src]="xomifyLogo" alt="Xomify" class="ticker-badge-logo" />
+          <span class="ticker-badge-label">Powered by Xomify</span>
+        </a>
+
+      </ng-container>
     </div>
+
+    <!-- Duplicate row for seamless loop — aria-hidden so AT only sees one set -->
     <div class="ticker-row ticker-row--b" aria-hidden="true">
-      <a
-        *ngFor="let item of items"
-        [href]="item.url"
-        target="_blank"
-        rel="noopener"
-        class="ticker-item"
-        [class.ticker-item--track]="item.type === 'track'"
-        [class.ticker-item--artist]="item.type === 'artist'"
-        tabindex="-1"
-      >
-        <img
-          [src]="item.imageUrl"
-          [alt]="item.type === 'track' ? item.label + ' album art' : item.label + ' artist photo'"
-          class="ticker-item-img"
-          loading="lazy"
-        />
-        <span class="ticker-item-text">
-          <span class="ticker-item-label">{{ item.label }}</span>
-          <span class="ticker-item-sub">{{ item.sub }}</span>
+      <ng-container *ngFor="let seg of segments">
+
+        <span class="ticker-divider" *ngIf="isDivider(seg)">
+          <span class="ticker-divider-timeframe">{{ seg.timeframe }}</span>
+          <span class="ticker-divider-sep" aria-hidden="true">·</span>
+          <span class="ticker-divider-label">{{ seg.label }}</span>
         </span>
-      </a>
+
+        <a
+          *ngIf="isItem(seg)"
+          [href]="seg.url"
+          target="_blank"
+          rel="noopener"
+          class="ticker-item"
+          [class.ticker-item--track]="seg.type === 'track'"
+          [class.ticker-item--artist]="seg.type === 'artist'"
+          [class.ticker-item--genre]="seg.type === 'genre'"
+          tabindex="-1"
+          aria-hidden="true"
+        >
+          <span class="ticker-item-img-wrap">
+            <img
+              *ngIf="seg.imageUrl"
+              [src]="seg.imageUrl"
+              [alt]="''"
+              class="ticker-item-img"
+              loading="lazy"
+            />
+            <span *ngIf="!seg.imageUrl" class="ticker-item-genre-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/></svg>
+            </span>
+          </span>
+          <span class="ticker-item-text">
+            <span class="ticker-item-label">{{ seg.label }}</span>
+            <span class="ticker-item-sub">{{ seg.sub }}</span>
+          </span>
+          <span class="ticker-dot" aria-hidden="true">·</span>
+        </a>
+
+        <a
+          *ngIf="isBadge(seg)"
+          [href]="xomifyUrl"
+          target="_blank"
+          rel="noopener"
+          class="ticker-badge"
+          tabindex="-1"
+          aria-hidden="true"
+        >
+          <img [src]="xomifyLogo" alt="" class="ticker-badge-logo" />
+          <span class="ticker-badge-label">Powered by Xomify</span>
+        </a>
+
+      </ng-container>
     </div>
   </div>
 </div>

--- a/src/app/components/music-ticker/music-ticker.component.scss
+++ b/src/app/components/music-ticker/music-ticker.component.scss
@@ -1,7 +1,8 @@
 @import 'styles/variables';
 
 $ticker-item-gap: $spacing-xl;
-$ticker-duration: 40s;
+// 25% faster than the original 40s
+$ticker-duration: 30s;
 
 .ticker-wrap {
   // Full-bleed: breaks out of any constrained parent container.
@@ -18,15 +19,6 @@ $ticker-duration: 40s;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   padding: $spacing-md 0;
-}
-
-.now-playing-slot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: $spacing-sm $spacing-xl;
-  border-bottom: 1px solid $glass-border;
-  margin-bottom: $spacing-md;
 }
 
 .ticker-track {
@@ -52,12 +44,49 @@ $ticker-duration: 40s;
 .ticker-row {
   display: flex;
   align-items: center;
-  gap: $ticker-item-gap;
+  gap: $spacing-md;
   padding: 0 calc($ticker-item-gap / 2);
 }
 
+// ── Category divider label ────────────────────────
+.ticker-divider {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
+  flex-shrink: 0;
+  // Left breathing room before each group
+  margin-left: $spacing-xl;
+}
+
+.ticker-divider-timeframe {
+  font-size: 10px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $text-muted;
+}
+
+.ticker-divider-sep {
+  color: $text-muted;
+  font-size: 12px;
+  opacity: 0.4;
+}
+
+.ticker-divider-label {
+  font-size: 10px;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: $brand-cyan;
+  padding: 2px $spacing-sm;
+  background: $brand-cyan-subtle;
+  border: 1px solid rgba($brand-cyan, 0.18);
+  border-radius: $radius-pill;
+}
+
+// ── Track / artist / genre items ──────────────────
 .ticker-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: $spacing-sm;
   text-decoration: none;
@@ -81,16 +110,43 @@ $ticker-duration: 40s;
   }
 }
 
+.ticker-item-img-wrap {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .ticker-item-img {
   width: 36px;
   height: 36px;
   object-fit: cover;
   border-radius: $radius-sm;
-  flex-shrink: 0;
   transition: box-shadow $transition-fast;
 
   .ticker-item--artist & {
     border-radius: 50%;
+  }
+}
+
+// Genre icon placeholder (music note in a subtle circle)
+.ticker-item-genre-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba($brand-cyan, 0.08);
+  border: 1px solid rgba($brand-cyan, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $brand-cyan;
+  flex-shrink: 0;
+
+  svg {
+    width: 18px;
+    height: 18px;
   }
 }
 
@@ -117,4 +173,55 @@ $ticker-duration: 40s;
   max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+// Inter-item dot separator
+.ticker-dot {
+  font-size: 12px;
+  color: $text-muted;
+  opacity: 0.35;
+  margin-left: $spacing-xs;
+  flex-shrink: 0;
+}
+
+// ── Powered by Xomify badge ───────────────────────
+.ticker-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
+  text-decoration: none;
+  flex-shrink: 0;
+  padding: 4px $spacing-md;
+  border-radius: $radius-pill;
+  background: rgba($xomify-purple, 0.08);
+  border: 1px solid rgba($xomify-purple, 0.2);
+  transition: background $transition-fast, border-color $transition-fast;
+  // Group boundary: more breathing room
+  margin-left: $spacing-xl;
+
+  &:hover {
+    background: rgba($xomify-purple, 0.15);
+    border-color: rgba($xomify-purple, 0.35);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $xomify-purple;
+    outline-offset: 2px;
+  }
+}
+
+.ticker-badge-logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+  border-radius: $radius-sm;
+  flex-shrink: 0;
+}
+
+.ticker-badge-label {
+  font-size: 11px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.02em;
+  color: rgba($xomify-purple, 0.85);
+  white-space: nowrap;
 }

--- a/src/app/components/music-ticker/music-ticker.component.ts
+++ b/src/app/components/music-ticker/music-ticker.component.ts
@@ -1,24 +1,43 @@
 import { Component, Input } from '@angular/core';
-import { MusicProfile, NowPlaying, TopArtist, TopTrack } from '../../models/music.model';
+import { MusicProfile, NowPlaying, TopArtist, TopTrack, TopGenre } from '../../models/music.model';
 
-interface TickerItem {
+/** A playable track or artist item in the marquee. */
+interface TickerTrackItem {
+  kind: 'item';
   label: string;
   sub: string;
   imageUrl: string;
   url: string;
-  type: 'track' | 'artist';
+  type: 'track' | 'artist' | 'genre';
 }
 
+/** A category label divider (e.g. "TOP TRACKS") shown before each group. */
+interface TickerDividerItem {
+  kind: 'divider';
+  label: string;
+  timeframe: string;
+}
+
+/** The "Powered by Xomify" badge shown at each group boundary. */
+interface TickerBadgeItem {
+  kind: 'badge';
+}
+
+export type TickerSegment = TickerTrackItem | TickerDividerItem | TickerBadgeItem;
+
+const XOMIFY_URL = 'https://xomify.xomware.com';
+const XOMIFY_LOGO = 'assets/img/xomify-logo.png';
+
 /**
- * Pure-CSS marquee that scrolls top tracks and top artists.
- * No GSAP — animation is driven entirely by CSS keyframes so there is
- * nothing to tear down in ngOnDestroy.
+ * Pure-CSS marquee that scrolls top tracks, artists, and genres as labeled
+ * groups with category dividers and "Powered by Xomify" badges at each
+ * group boundary.
  *
  * Usage:
  *   <app-music-ticker [profile]="musicProfile" [nowPlaying]="null"></app-music-ticker>
  *
- * Built standalone-friendly so it can be dropped on the landing page later.
- * The `nowPlaying` slot is reserved but unused in v1 (always null).
+ * No GSAP — animation is driven by CSS keyframes so there is nothing to tear
+ * down in ngOnDestroy.
  */
 @Component({
   selector: 'app-music-ticker',
@@ -30,29 +49,81 @@ export class MusicTickerComponent {
   /** Reserved for v2 now-playing. Pass null in v1. */
   @Input() nowPlaying: NowPlaying | null = null;
 
-  get items(): TickerItem[] {
+  /** Expose constants for template use. */
+  readonly xomifyUrl = XOMIFY_URL;
+  readonly xomifyLogo = XOMIFY_LOGO;
+
+  get timeframeLabel(): string {
+    return this.profile?.windowLabel ?? '';
+  }
+
+  get segments(): TickerSegment[] {
     if (!this.profile) return [];
 
-    const tracks: TickerItem[] = this.profile.topTracks.map(
-      (t: TopTrack): TickerItem => ({
-        label: t.name,
-        sub: t.artist,
-        imageUrl: t.albumArt,
-        url: t.url,
-        type: 'track',
-      }),
-    );
+    const tf = this.timeframeLabel;
+    const result: TickerSegment[] = [];
 
-    const artists: TickerItem[] = this.profile.topArtists.map(
-      (a: TopArtist): TickerItem => ({
-        label: a.name,
-        sub: 'Artist',
-        imageUrl: a.image,
-        url: a.url,
-        type: 'artist',
-      }),
-    );
+    // ── TOP TRACKS ──────────────────────────────────
+    if (this.profile.topTracks.length > 0) {
+      result.push({ kind: 'divider', label: 'TOP TRACKS', timeframe: tf });
+      for (const t of this.profile.topTracks) {
+        result.push({
+          kind: 'item',
+          label: t.name,
+          sub: t.artist,
+          imageUrl: t.albumArt,
+          url: t.url,
+          type: 'track',
+        });
+      }
+      result.push({ kind: 'badge' });
+    }
 
-    return [...tracks, ...artists];
+    // ── TOP ARTISTS ─────────────────────────────────
+    if (this.profile.topArtists.length > 0) {
+      result.push({ kind: 'divider', label: 'TOP ARTISTS', timeframe: tf });
+      for (const a of this.profile.topArtists) {
+        result.push({
+          kind: 'item',
+          label: a.name,
+          sub: 'Artist',
+          imageUrl: a.image,
+          url: a.url,
+          type: 'artist',
+        });
+      }
+      result.push({ kind: 'badge' });
+    }
+
+    // ── TOP GENRES ──────────────────────────────────
+    if (this.profile.topGenres.length > 0) {
+      result.push({ kind: 'divider', label: 'TOP GENRES', timeframe: tf });
+      for (const g of this.profile.topGenres) {
+        result.push({
+          kind: 'item',
+          label: g.genre,
+          sub: `${g.count} tracks`,
+          // Genres have no image — use a genre icon placeholder via CSS class
+          imageUrl: '',
+          url: XOMIFY_URL,
+          type: 'genre',
+        });
+      }
+      result.push({ kind: 'badge' });
+    }
+
+    return result;
+  }
+
+  isItem(s: TickerSegment): s is TickerTrackItem {
+    return s.kind === 'item';
+  }
+
+  isDivider(s: TickerSegment): s is TickerDividerItem {
+    return s.kind === 'divider';
+  }
+
+  isBadge(s: TickerSegment): s is TickerBadgeItem {
+    return s.kind === 'badge';
   }
 }

--- a/src/app/components/music/music.component.html
+++ b/src/app/components/music/music.component.html
@@ -1,6 +1,17 @@
 <div class="music-page">
-  <!-- Shared site navbar -->
-  <app-nav></app-nav>
+  <!-- Ambient backdrop — same blobs + lightning as landing (position:fixed, pointer-events:none) -->
+  <app-monster></app-monster>
+
+  <!-- Shared site navbar — always-scrolled so the solid background is immediate
+       (no tall hero here, transparent nav would make links unreadable at the top) -->
+  <app-nav [alwaysScrolled]="true"></app-nav>
+
+  <!-- ── Music ticker — page-level strip directly under the nav ──────────── -->
+  <!-- Rendered once, always visible (regardless of active tab), fed from the
+       Now tab's short_term top-items fetch. Hidden until data is ready. -->
+  <div class="music-ticker-bar" *ngIf="profile" aria-label="Now listening ticker">
+    <app-music-ticker [profile]="profile" [nowPlaying]="null"></app-music-ticker>
+  </div>
 
   <!-- Hero / page title -->
   <section class="music-hero">
@@ -153,9 +164,6 @@
           <span class="range-loading-dot"></span>
         </span>
       </div>
-
-      <!-- Ticker — full-bleed, reflects the current range -->
-      <app-music-ticker [profile]="profile" [nowPlaying]="null"></app-music-ticker>
 
       <main class="music-content">
 

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -9,14 +9,29 @@
   flex-direction: column;
 }
 
+// ── Page-level ticker bar (under nav, above hero) ────
+.music-ticker-bar {
+  // Sits directly below the fixed nav (57px) — acts as the first element
+  // the user sees, edge-anchored like a header strip.
+  position: relative;
+  z-index: 1;
+  margin-top: 57px; // nav height
+
+  // The ticker component uses the full-bleed breakout pattern internally.
+  // Our container just needs to be position:relative with no overflow:hidden
+  // so the negative-margin breakout can escape.
+  overflow: visible;
+}
+
 // ── Hero ─────────────────────────────────────────────
 .music-hero {
   background: $hero-gradient;
-  // Push down below the fixed AppNavComponent (~57px tall)
-  padding: calc($spacing-4xl + 57px) $spacing-xl $spacing-3xl;
+  // The fixed nav (57px) + ticker bar are already above this.
+  // Just add normal section padding — no extra nav offset needed.
+  padding: $spacing-4xl $spacing-xl $spacing-3xl;
 
   @media (max-width: $breakpoint-md) {
-    padding: calc($spacing-3xl + 57px) $spacing-md $spacing-2xl;
+    padding: $spacing-3xl $spacing-md $spacing-2xl;
   }
 }
 
@@ -216,45 +231,66 @@
   color: $text-muted;
 }
 
-// ── Time-range switcher ───────────────────────────────
+// ── Time-range segmented control ─────────────────────
+//
+// Glass tray containing pill-shaped option segments.
+// Active segment gets a filled brand-cyan pill with dark text;
+// inactive segments are ghost and fade-hover.
+//
 .range-switcher {
   display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: $spacing-xs;
+  background: $bg-glass-heavy;
   border: 1px solid $glass-border;
   border-radius: $radius-pill;
-  overflow: hidden;
-  gap: 0;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .range-btn {
-  background: none;
+  position: relative;
+  background: transparent;
   border: none;
-  padding: $spacing-xs $spacing-md;
+  border-radius: $radius-pill;
+  padding: 5px $spacing-md;
   font-size: 12px;
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-semibold;
   font-family: $font-stack;
   color: $text-secondary;
   cursor: pointer;
-  transition: background $transition-fast, color $transition-fast;
   white-space: nowrap;
+  letter-spacing: 0.01em;
+  transition:
+    color $transition-fast,
+    background $transition-fast,
+    box-shadow $transition-fast;
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled):not(.range-btn--active) {
     color: $text-primary;
     background: rgba(255, 255, 255, 0.06);
   }
 
   &:focus-visible {
     outline: 2px solid $brand-cyan;
-    outline-offset: -2px;
+    outline-offset: 2px;
+    border-radius: $radius-pill;
   }
 
   &--active {
-    background: rgba($brand-cyan, 0.12);
-    color: $brand-cyan;
+    background: $brand-cyan;
+    color: $bg-dark;
+    box-shadow: 0 2px 12px rgba(0, 180, 216, 0.35);
   }
 
   &:disabled {
-    opacity: 0.5;
+    opacity: 0.45;
     cursor: not-allowed;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    padding: 5px $spacing-sm;
   }
 }
 

--- a/src/app/components/nav/app-nav.component.ts
+++ b/src/app/components/nav/app-nav.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ElementRef,
   HostListener,
+  Input,
   OnDestroy,
   OnInit,
 } from '@angular/core';
@@ -22,6 +23,13 @@ interface ReportTarget {
   styleUrls: ['./app-nav.component.scss'],
 })
 export class AppNavComponent implements OnInit, OnDestroy {
+  /**
+   * When true the nav always renders with its solid/scrolled background —
+   * use this on pages without a tall hero where the transparent nav would
+   * float over a light-colored or empty background and make links unreadable.
+   */
+  @Input() alwaysScrolled = false;
+
   isScrolled = false;
   menuOpen = false;
   reportMenuOpen = false;
@@ -45,7 +53,7 @@ export class AppNavComponent implements OnInit, OnDestroy {
       (p) => (this.profile = p),
     );
     // Seed scroll state in case the component mounts after the user has scrolled.
-    this.isScrolled = window.scrollY > 50;
+    this.isScrolled = this.alwaysScrolled || window.scrollY > 50;
   }
 
   ngOnDestroy(): void {
@@ -101,7 +109,7 @@ export class AppNavComponent implements OnInit, OnDestroy {
 
   @HostListener('window:scroll')
   onScroll(): void {
-    this.isScrolled = window.scrollY > 50;
+    this.isScrolled = this.alwaysScrolled || window.scrollY > 50;
   }
 
   @HostListener('document:click', ['$event'])

--- a/src/app/components/now-playing/now-playing.component.ts
+++ b/src/app/components/now-playing/now-playing.component.ts
@@ -4,14 +4,22 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { Subscription, interval } from 'rxjs';
-import { switchMap, startWith } from 'rxjs/operators';
+import { Subscription, interval, of } from 'rxjs';
+import { switchMap, startWith, catchError } from 'rxjs/operators';
 import { NowPlayingService } from '../../services/now-playing.service';
 import { NowPlayingState } from '../../models/now-playing.model';
 import { environment } from '../../../environments/environment';
 
 /** Polling interval in milliseconds. */
 const POLL_INTERVAL_MS = 25_000;
+
+/** Safe idle state emitted when a poll request errors, so the interval keeps firing. */
+const IDLE_STATE: NowPlayingState = {
+  isPlaying: false,
+  track: null,
+  progressMs: null,
+  durationMs: null,
+};
 
 /**
  * Polls the now-playing endpoint every 25 seconds and displays the
@@ -43,16 +51,15 @@ export class NowPlayingComponent implements OnInit, OnDestroy {
       .pipe(
         startWith(0),
         switchMap(() =>
-          this.nowPlayingService.getNowPlaying(environment.musicProfileUserId),
+          this.nowPlayingService
+            .getNowPlaying(environment.musicProfileUserId)
+            .pipe(
+              // On error emit a safe idle state so the outer interval keeps firing.
+              catchError(() => of(IDLE_STATE)),
+            ),
         ),
       )
-      .subscribe({
-        next: (s) => (this.state = s),
-        error: () => {
-          // On error, keep stale state if available; otherwise null.
-          if (!this.state) this.state = null;
-        },
-      });
+      .subscribe((s) => (this.state = s));
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
- **/music ambient backdrop**: adds `<app-monster>` (bubbles + lightning) so the page feels part of the site.
- **Nav parity**: `alwaysScrolled` on /music so the shared nav is solid from the top.
- **Ticker**: moved to directly under the nav (/music) and footer (landing); full-width edge strips; regrouped into Top Tracks / Top Artists / Top Genres with dividers + a timeframe label, a clickable 'Powered by Xomify' badge at each group boundary, and ~25% faster scroll.
- **Range toggle**: restyled into an on-brand segmented control.
- **Now Playing**: resilient polling (catchError so a transient error no longer kills the interval).

Verified locally via headless render: monster+lightning on /music, ticker placement/grouping/badge, restyled toggle, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)