### PR TITLE
now-playing: Last played display + polish

### DIFF
--- a/src/app/components/music-ticker/music-ticker.component.html
+++ b/src/app/components/music-ticker/music-ticker.component.html
@@ -6,10 +6,11 @@
     <div class="ticker-row ticker-row--a">
       <ng-container *ngFor="let seg of segments">
 
-        <!-- Category divider / label -->
+        <!-- Leading timeframe label — rendered once at the front of the sequence -->
+        <span class="ticker-timeframe" *ngIf="isTimeframe(seg)">{{ seg.label }}</span>
+
+        <!-- Category divider / label (no timeframe prefix) -->
         <span class="ticker-divider" *ngIf="isDivider(seg)">
-          <span class="ticker-divider-timeframe">{{ seg.timeframe }}</span>
-          <span class="ticker-divider-sep" aria-hidden="true">·</span>
           <span class="ticker-divider-label">{{ seg.label }}</span>
         </span>
 
@@ -64,9 +65,9 @@
     <div class="ticker-row ticker-row--b" aria-hidden="true">
       <ng-container *ngFor="let seg of segments">
 
+        <span class="ticker-timeframe" *ngIf="isTimeframe(seg)">{{ seg.label }}</span>
+
         <span class="ticker-divider" *ngIf="isDivider(seg)">
-          <span class="ticker-divider-timeframe">{{ seg.timeframe }}</span>
-          <span class="ticker-divider-sep" aria-hidden="true">·</span>
           <span class="ticker-divider-label">{{ seg.label }}</span>
         </span>
 

--- a/src/app/components/music-ticker/music-ticker.component.scss
+++ b/src/app/components/music-ticker/music-ticker.component.scss
@@ -48,6 +48,20 @@ $ticker-duration: 30s;
   padding: 0 calc($ticker-item-gap / 2);
 }
 
+// ── Leading timeframe label (once at front of sequence) ──
+.ticker-timeframe {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $text-muted;
+  // Breathing room at the very front
+  margin-right: $spacing-md;
+}
+
 // ── Category divider label ────────────────────────
 .ticker-divider {
   display: inline-flex;
@@ -56,20 +70,6 @@ $ticker-duration: 30s;
   flex-shrink: 0;
   // Left breathing room before each group
   margin-left: $spacing-xl;
-}
-
-.ticker-divider-timeframe {
-  font-size: 10px;
-  font-weight: $font-weight-semibold;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: $text-muted;
-}
-
-.ticker-divider-sep {
-  color: $text-muted;
-  font-size: 12px;
-  opacity: 0.4;
 }
 
 .ticker-divider-label {

--- a/src/app/components/music-ticker/music-ticker.component.ts
+++ b/src/app/components/music-ticker/music-ticker.component.ts
@@ -15,7 +15,12 @@ interface TickerTrackItem {
 interface TickerDividerItem {
   kind: 'divider';
   label: string;
-  timeframe: string;
+}
+
+/** A single leading timeframe label shown once at the front of the sequence. */
+interface TickerTimeframeItem {
+  kind: 'timeframe';
+  label: string;
 }
 
 /** The "Powered by Xomify" badge shown at each group boundary. */
@@ -23,7 +28,7 @@ interface TickerBadgeItem {
   kind: 'badge';
 }
 
-export type TickerSegment = TickerTrackItem | TickerDividerItem | TickerBadgeItem;
+export type TickerSegment = TickerTrackItem | TickerDividerItem | TickerTimeframeItem | TickerBadgeItem;
 
 const XOMIFY_URL = 'https://xomify.xomware.com';
 const XOMIFY_LOGO = 'assets/img/xomify-logo.png';
@@ -63,9 +68,14 @@ export class MusicTickerComponent {
     const tf = this.timeframeLabel;
     const result: TickerSegment[] = [];
 
+    // ── Leading timeframe label (once, at the front) ─
+    if (tf) {
+      result.push({ kind: 'timeframe', label: tf });
+    }
+
     // ── TOP TRACKS ──────────────────────────────────
     if (this.profile.topTracks.length > 0) {
-      result.push({ kind: 'divider', label: 'TOP TRACKS', timeframe: tf });
+      result.push({ kind: 'divider', label: 'TOP TRACKS' });
       for (const t of this.profile.topTracks) {
         result.push({
           kind: 'item',
@@ -81,7 +91,7 @@ export class MusicTickerComponent {
 
     // ── TOP ARTISTS ─────────────────────────────────
     if (this.profile.topArtists.length > 0) {
-      result.push({ kind: 'divider', label: 'TOP ARTISTS', timeframe: tf });
+      result.push({ kind: 'divider', label: 'TOP ARTISTS' });
       for (const a of this.profile.topArtists) {
         result.push({
           kind: 'item',
@@ -97,7 +107,7 @@ export class MusicTickerComponent {
 
     // ── TOP GENRES ──────────────────────────────────
     if (this.profile.topGenres.length > 0) {
-      result.push({ kind: 'divider', label: 'TOP GENRES', timeframe: tf });
+      result.push({ kind: 'divider', label: 'TOP GENRES' });
       for (const g of this.profile.topGenres) {
         result.push({
           kind: 'item',
@@ -121,6 +131,10 @@ export class MusicTickerComponent {
 
   isDivider(s: TickerSegment): s is TickerDividerItem {
     return s.kind === 'divider';
+  }
+
+  isTimeframe(s: TickerSegment): s is TickerTimeframeItem {
+    return s.kind === 'timeframe';
   }
 
   isBadge(s: TickerSegment): s is TickerBadgeItem {

--- a/src/app/components/music/music.component.html
+++ b/src/app/components/music/music.component.html
@@ -138,10 +138,8 @@
 
     <!-- Loaded state -->
     <ng-container *ngIf="state === 'loaded' && profile">
-      <!-- Meta: window + range switcher + updated timestamp -->
+      <!-- Meta: range switcher + updated timestamp -->
       <div class="music-meta">
-        <span class="music-meta-window">{{ profile.windowLabel }}</span>
-
         <!-- Time-range toggle (segmented control) -->
         <div
           class="range-switcher"

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -214,17 +214,6 @@
   }
 }
 
-.music-meta-window {
-  font-size: 12px;
-  font-weight: $font-weight-medium;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: $brand-cyan;
-  background: $brand-cyan-subtle;
-  border: 1px solid rgba(0, 180, 216, 0.2);
-  border-radius: $radius-pill;
-  padding: $spacing-xs $spacing-md;
-}
 
 .music-meta-updated {
   font-size: 12px;

--- a/src/app/components/now-playing/now-playing.component.html
+++ b/src/app/components/now-playing/now-playing.component.html
@@ -1,7 +1,8 @@
 <ng-container *ngIf="isVisible">
-  <!-- Active: playing track card -->
+
+  <!-- ── Playing: actively playing track ──────────────────── -->
   <div
-    *ngIf="state?.isPlaying && state?.track; else idleState"
+    *ngIf="state?.source === 'playing' && state?.track; else recentOrIdle"
     class="now-playing"
     aria-label="Now playing"
     role="region"
@@ -36,7 +37,7 @@
         <span class="now-playing-artist">{{ state!.track!.artist }}</span>
       </div>
 
-      <!-- Progress bar (only on /music, where durationMs is meaningful) -->
+      <!-- Progress bar (only when durationMs available) -->
       <div
         *ngIf="state!.durationMs"
         class="now-playing-progress-wrap"
@@ -66,20 +67,75 @@
     </a>
   </div>
 
-  <!-- Idle: "not playing" placeholder (only shown when showWhenIdle=true) -->
-  <ng-template #idleState>
-    <div class="now-playing now-playing--idle" role="region" aria-label="Not playing right now">
-      <div class="now-playing-inner now-playing-inner--idle">
-        <div class="now-playing-art-wrap now-playing-art-wrap--idle" aria-hidden="true">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="now-playing-idle-icon">
-            <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/>
-          </svg>
+  <!-- ── Recent / Idle fallback ────────────────────────────── -->
+  <ng-template #recentOrIdle>
+
+    <!-- Recent: last-played track (no bars, no progress) -->
+    <div
+      *ngIf="state?.source === 'recent' && state?.track; else idleState"
+      class="now-playing now-playing--recent"
+      aria-label="Last played"
+      role="region"
+    >
+      <a
+        [href]="state!.track!.url"
+        target="_blank"
+        rel="noopener"
+        class="now-playing-inner"
+        [attr.aria-label]="state!.track!.name + ' by ' + state!.track!.artist + ' — last played, open on Spotify'"
+      >
+        <!-- Album art (no animated bars) -->
+        <div class="now-playing-art-wrap">
+          <img
+            [src]="state!.track!.albumArt"
+            [alt]="state!.track!.name + ' album art'"
+            class="now-playing-art"
+            loading="eager"
+          />
         </div>
+
+        <!-- Track info -->
         <div class="now-playing-info">
-          <span class="now-playing-label">Spotify</span>
-          <span class="now-playing-track now-playing-track--idle">Not playing right now</span>
+          <span class="now-playing-label now-playing-label--recent">
+            Last played
+            <span
+              *ngIf="state!.playedAt"
+              class="now-playing-played-at"
+            >{{ relativeTime(state!.playedAt!) }}</span>
+          </span>
+          <span class="now-playing-track">{{ state!.track!.name }}</span>
+          <span class="now-playing-artist">{{ state!.track!.artist }}</span>
+        </div>
+
+        <!-- Spotify icon -->
+        <svg
+          class="now-playing-spotify-icon"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" fill="currentColor"/>
+        </svg>
+      </a>
+    </div>
+
+    <!-- None / idle: show only when showWhenIdle=true (/music placement) -->
+    <ng-template #idleState>
+      <div class="now-playing now-playing--idle" role="region" aria-label="Not playing right now">
+        <div class="now-playing-inner now-playing-inner--idle">
+          <div class="now-playing-art-wrap now-playing-art-wrap--idle" aria-hidden="true">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="now-playing-idle-icon">
+              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/>
+            </svg>
+          </div>
+          <div class="now-playing-info">
+            <span class="now-playing-label">Spotify</span>
+            <span class="now-playing-track now-playing-track--idle">Not playing right now</span>
+          </div>
         </div>
       </div>
-    </div>
+    </ng-template>
+
   </ng-template>
+
 </ng-container>

--- a/src/app/components/now-playing/now-playing.component.scss
+++ b/src/app/components/now-playing/now-playing.component.scss
@@ -8,6 +8,11 @@
   &--idle {
     opacity: 0.55;
   }
+
+  &--recent {
+    // Slightly dimmed vs actively playing — still readable, not idle-level fade
+    opacity: 0.85;
+  }
 }
 
 .now-playing-inner {
@@ -124,11 +129,27 @@
 }
 
 .now-playing-label {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
   font-size: 10px;
   font-weight: $font-weight-semibold;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: $brand-cyan;
+
+  &--recent {
+    color: $text-muted;
+  }
+}
+
+.now-playing-played-at {
+  font-size: 10px;
+  font-weight: $font-weight-medium;
+  text-transform: none;
+  letter-spacing: 0;
+  color: $text-muted;
+  opacity: 0.7;
 }
 
 .now-playing-track {
@@ -201,7 +222,7 @@
   }
 }
 
-// ── Compact landing pill variant ─────────────────────
-// The landing uses this component with showWhenIdle=false,
-// so we only see it when something is playing.
-// No extra variant styles needed — the default card works.
+// ── Landing placement notes ───────────────────────────
+// showWhenIdle=false (landing): visible when source==='playing' OR source==='recent'
+//   → landing will almost always show either "Now playing" or "Last played"
+// showWhenIdle=true (/music): also shows the idle placeholder when source==='none'

--- a/src/app/components/now-playing/now-playing.component.ts
+++ b/src/app/components/now-playing/now-playing.component.ts
@@ -19,6 +19,8 @@ const IDLE_STATE: NowPlayingState = {
   track: null,
   progressMs: null,
   durationMs: null,
+  source: 'none',
+  playedAt: null,
 };
 
 /**
@@ -71,9 +73,37 @@ export class NowPlayingComponent implements OnInit, OnDestroy {
     return Math.min(100, (this.state.progressMs / this.state.durationMs) * 100);
   }
 
+  /**
+   * Show whenever there is a track (playing or recent).
+   * When source === 'none', only show if showWhenIdle (the /music page idle placeholder).
+   */
   get isVisible(): boolean {
     if (!this.state) return false;
-    if (this.state.isPlaying && this.state.track) return true;
+    if (this.state.track) return true;
     return this.showWhenIdle;
+  }
+
+  /** Human-readable relative time from an ISO string (e.g. "2h ago"). */
+  relativeTime(iso: string): string {
+    const diffMs = Date.now() - new Date(iso).getTime();
+    const diffMins = Math.floor(diffMs / 60_000);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays === 1) return '1 day ago';
+    if (diffDays < 30) return `${diffDays} days ago`;
+
+    const diffWeeks = Math.floor(diffDays / 7);
+    if (diffWeeks === 1) return '1 week ago';
+    if (diffWeeks < 8) return `${diffWeeks} weeks ago`;
+
+    const diffMonths = Math.floor(diffDays / 30);
+    if (diffMonths === 1) return '1 month ago';
+    return `${diffMonths} months ago`;
   }
 }

--- a/src/app/models/now-playing.model.ts
+++ b/src/app/models/now-playing.model.ts
@@ -10,4 +10,8 @@ export interface NowPlayingState {
   track: NowPlayingTrack | null;
   progressMs: number | null;
   durationMs: number | null;
+  /** 'playing' = actively playing; 'recent' = last played fallback; 'none' = nothing available. */
+  source: 'playing' | 'recent' | 'none';
+  /** ISO timestamp set when source === 'recent'. */
+  playedAt: string | null;
 }


### PR DESCRIPTION
- now-playing renders 'Last played' + relative time for `source=recent`; landing shows it instead of hiding.
- Removes redundant range pill next to the toggle.
- Ticker timeframe label shows once at the front (not per group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)