### PR TITLE
Music polish: equal columns, contained tabs, Home link, month dropdown, snapshot fade fix

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -115,11 +115,6 @@
           <svg viewBox="0 0 24 24" class="btn-icon"><path d="M16.01 11H4v2h12.01v3L20 12l-3.99-4z" fill="currentColor"/></svg>
         </a>
       </div>
-      <!-- Music snapshot module — replaces the isolated now-playing pill -->
-      <app-music-snapshot
-        [profile]="landingTickerProfile"
-        [nowPlayingState]="nowPlayingState"
-      ></app-music-snapshot>
     </div>
     <!-- Scroll hint -->
     <div class="scroll-hint">
@@ -129,6 +124,16 @@
       </svg>
     </div>
   </header>
+
+  <!-- Music snapshot — outside .hero-content so it is NOT faded by the
+       hero ScrollTrigger (which targets .hero-content only). Sits in its
+       own section between the hero and the app cards. -->
+  <section class="music-snapshot-section" *ngIf="landingTickerProfile" aria-label="Now playing">
+    <app-music-snapshot
+      [profile]="landingTickerProfile"
+      [nowPlayingState]="nowPlayingState"
+    ></app-music-snapshot>
+  </section>
 
   <!-- App Cards Section -->
   <section class="apps-section" id="apps">

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -791,6 +791,20 @@
   flex-shrink: 0;
 }
 
+// ── Music snapshot section (between hero and apps) ────
+// Moved outside .hero-content so the hero ScrollTrigger fade does not
+// affect this element. Sits as its own in-flow block after the hero.
+.music-snapshot-section {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 $spacing-xl $spacing-3xl;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 0 $spacing-md $spacing-2xl;
+  }
+}
+
 // ── Responsive ───────────────────────────────────
 @media (max-width: $breakpoint-lg) {
   .cards-container {

--- a/src/app/components/music-wrapped/music-wrapped.component.html
+++ b/src/app/components/music-wrapped/music-wrapped.component.html
@@ -41,18 +41,26 @@
   </p>
 
   <ng-container *ngIf="archive.months.length > 0 && selectedMonth">
-    <!-- Month selector chips -->
-    <div class="month-selector" role="group" aria-label="Select month">
-      <button
-        *ngFor="let month of archive.months; trackBy: trackByMonthKey"
-        type="button"
-        class="month-chip"
-        [class.month-chip--active]="month.monthKey === selectedMonthKey"
-        [attr.aria-pressed]="month.monthKey === selectedMonthKey"
-        (click)="selectMonth(month.monthKey)"
-      >
-        {{ month.label }}
-      </button>
+    <!-- Month selector dropdown -->
+    <div class="month-selector">
+      <label for="wrapped-month-select" class="month-selector-label">Month</label>
+      <div class="month-select-wrapper">
+        <select
+          id="wrapped-month-select"
+          class="month-select"
+          [value]="selectedMonthKey"
+          (change)="selectMonth($any($event.target).value)"
+          aria-label="Select wrapped month"
+        >
+          <option
+            *ngFor="let month of archive.months; trackBy: trackByMonthKey"
+            [value]="month.monthKey"
+          >{{ month.label }}</option>
+        </select>
+        <svg class="month-select-caret" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" fill="currentColor"/>
+        </svg>
+      </div>
     </div>
 
     <!-- Playlist CTA -->

--- a/src/app/components/music-wrapped/music-wrapped.component.scss
+++ b/src/app/components/music-wrapped/music-wrapped.component.scss
@@ -154,50 +154,80 @@
   text-align: center;
 }
 
-// ── Month selector chips ──────────────────────────────
+// ── Month selector dropdown ───────────────────────────
 .month-selector {
   display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-sm;
+  align-items: center;
+  gap: $spacing-md;
   margin-bottom: $spacing-xl;
 }
 
-.month-chip {
+.month-selector-label {
   font-size: 13px;
+  font-weight: $font-weight-semibold;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.month-select-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.month-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: $bg-glass-heavy;
+  border: 1px solid $glass-border;
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: 14px;
   font-weight: $font-weight-medium;
   font-family: $font-stack;
-  color: $text-secondary;
-  background: $bg-card;
-  border: 1px solid $glass-border;
-  border-radius: $radius-pill;
-  padding: $spacing-xs $spacing-md;
+  padding: $spacing-sm $spacing-3xl $spacing-sm $spacing-md;
   cursor: pointer;
   transition:
-    background $transition-fast,
-    color $transition-fast,
-    border-color $transition-fast;
+    border-color $transition-fast,
+    background $transition-fast;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  min-width: 160px;
+
+  // Option background inherits from system; can't style option internals
+  // cross-browser, so keep select bg dark for contrast.
+  option {
+    background: #141428;
+    color: $text-primary;
+  }
 
   &:hover {
-    background: $bg-card-hover;
-    color: $text-primary;
     border-color: $glass-border-hover;
   }
 
   &:focus-visible {
     outline: 2px solid $brand-cyan;
     outline-offset: 2px;
+    border-color: $brand-cyan;
   }
 
-  &--active {
-    background: $brand-cyan-subtle;
-    color: $brand-cyan;
-    border-color: rgba(0, 180, 216, 0.3);
-
-    &:hover {
-      background: rgba(0, 180, 216, 0.14);
-      color: $brand-cyan-light;
-    }
+  @media (max-width: $breakpoint-sm) {
+    min-width: 140px;
+    font-size: 13px;
   }
+}
+
+.month-select-caret {
+  position: absolute;
+  right: $spacing-sm;
+  width: 16px;
+  height: 16px;
+  color: $text-muted;
+  pointer-events: none;
+  flex-shrink: 0;
 }
 
 // ── Playlist CTA ─────────────────────────────────────
@@ -247,7 +277,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: $spacing-xl;
-  align-items: start;
+  align-items: stretch;
 
   @media (max-width: $breakpoint-lg) {
     grid-template-columns: repeat(2, 1fr);
@@ -261,10 +291,12 @@
 }
 
 // ── Section shared ───────────────────────────────────
+// height: 100% + flex-column stretches all three cards to the tallest.
 .wrapped-section {
   display: flex;
   flex-direction: column;
   gap: $spacing-lg;
+  height: 100%;
   background: rgba(20, 20, 40, 0.45);
   border: 1px solid $glass-border;
   border-radius: $radius-lg;

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -94,19 +94,12 @@
   }
 }
 
-// ── Tab navigation — sticky below nav + ticker ────────
-// No full-width border-bottom: the border was spanning the entire viewport
-// making tabs look disconnected from content. Instead the active-tab indicator
-// (border-bottom on .music-tab--active) is scoped to just the tab width.
+// ── Tab navigation — inline strip, contained to content width ────────
+// Not sticky: the full-width sticky band looked like a floating bar
+// disconnected from the cards below. Now it flows with the page content,
+// contained to the same max-width as the cards.
 .music-tabs-nav {
-  background: $bg-glass-heavy;
-  backdrop-filter: $glass-blur;
-  -webkit-backdrop-filter: $glass-blur;
-  border-bottom: 1px solid $glass-border;
-  position: sticky;
-  // Pin directly below the sticky ticker: nav height + ticker height.
-  top: calc(var(--nav-h) + var(--ticker-h));
-  z-index: 80;
+  // No full-width line — the underline is contained to content width below.
 }
 
 .music-tabs-inner {
@@ -115,6 +108,7 @@
   padding: 0 $spacing-xl;
   display: flex;
   gap: 0;
+  border-bottom: 1px solid $glass-border;
 
   @media (max-width: $breakpoint-md) {
     padding: 0 $spacing-md;
@@ -431,7 +425,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: $spacing-xl;
-  align-items: start;
+  align-items: stretch;
 
   @media (max-width: $breakpoint-lg) {
     max-width: 900px;
@@ -450,10 +444,12 @@
 // ── Section shared ───────────────────────────────────
 // Each section is one grid column. background + border give it a card feel
 // so the 3-col layout reads as a dashboard, not a raw grid.
+// height: 100% + flex-column lets all three cards stretch to equal height.
 .music-section {
   display: flex;
   flex-direction: column;
   gap: $spacing-lg;
+  height: 100%;
   background: rgba(20, 20, 40, 0.45);
   border: 1px solid $glass-border;
   border-radius: $radius-lg;

--- a/src/app/components/nav/app-nav.component.html
+++ b/src/app/components/nav/app-nav.component.html
@@ -6,6 +6,7 @@
       <span class="nav-wordmark">XOMWARE</span>
     </a>
     <div class="nav-links">
+      <a routerLink="/" class="nav-link">Home</a>
       <a routerLink="/" fragment="apps" class="nav-link">Apps</a>
       <a routerLink="/music" class="nav-link">Music</a>
       <a href="https://github.com/Xomware" target="_blank" rel="noopener" class="nav-link nav-link-github">
@@ -109,6 +110,7 @@
 <!-- Mobile Menu Overlay -->
 <div class="mobile-menu-overlay" [class.open]="menuOpen" (click)="closeMenu()">
   <nav class="mobile-menu" aria-label="Mobile navigation" (click)="$event.stopPropagation()">
+    <a routerLink="/" class="mobile-menu-link" (click)="closeMenu()">Home</a>
     <a routerLink="/" fragment="apps" class="mobile-menu-link" (click)="closeMenu()">Apps</a>
     <a routerLink="/music" class="mobile-menu-link" (click)="closeMenu()">Music</a>
     <a href="https://github.com/Xomware" target="_blank" rel="noopener" class="mobile-menu-link" (click)="closeMenu()">


### PR DESCRIPTION
- **Equal-height columns** on Now + Wrapped (Tracks/Artists/Genres unified).
- **Tab strip**: removed sticky + full-width band/line; underline now contained to content width (fixes the 'bar across' look).
- **Landing snapshot** moved out of `.hero-content` so it no longer fades out early on scroll.
- **Home** link added to nav (desktop + mobile).
- **Wrapped month selector** → dropdown instead of a row of pills.

Verified /music via headless render: equal card heights (468/468 Now, 465/465 Wrapped), contained tab underline, dropdown with months, Home in nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)