### PR TITLE
Music: equal-width columns (minmax(0,1fr))

### DIFF
--- a/src/app/components/music-wrapped/music-wrapped.component.scss
+++ b/src/app/components/music-wrapped/music-wrapped.component.scss
@@ -275,12 +275,13 @@
 // desktop, stacked on mobile.
 .wrapped-columns {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  // minmax(0, 1fr) forces truly equal columns regardless of content width.
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: $spacing-xl;
   align-items: stretch;
 
   @media (max-width: $breakpoint-lg) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: $spacing-lg;
   }
 

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -423,14 +423,16 @@
   padding: $spacing-3xl $spacing-xl;
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  // minmax(0, 1fr) (not bare 1fr) forces truly equal columns — otherwise the
+  // Tracks column grows to fit long titles and Genres shrinks.
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: $spacing-xl;
   align-items: stretch;
 
   @media (max-width: $breakpoint-lg) {
     max-width: 900px;
     // 2-column: Tracks | Artists, then Genres full-width
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: $spacing-lg;
   }
 


### PR DESCRIPTION
The 3-column layout had uneven widths (Genres ~284px vs Tracks ~360px) because bare `1fr` = `minmax(auto,1fr)` lets columns grow to content min-width. Switched to `minmax(0,1fr)` so all three columns are truly equal width on Now + Wrapped. Verified: [324,324,324].

🤖 Generated with [Claude Code](https://claude.com/claude-code)