### PR TITLE
Music: handle long track titles (ellipsis, no column bleed)

### DIFF
--- a/src/app/components/music-wrapped/music-wrapped.component.scss
+++ b/src/app/components/music-wrapped/music-wrapped.component.scss
@@ -334,6 +334,7 @@
   display: flex;
   align-items: center;
   gap: $spacing-md;
+  min-width: 0;
 }
 
 .track-rank {
@@ -350,6 +351,7 @@
   align-items: center;
   gap: $spacing-md;
   flex: 1;
+  min-width: 0; // lets .track-name ellipsis engage instead of overflowing the column
   text-decoration: none;
   color: $text-primary;
   padding: $spacing-sm $spacing-md;

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -532,6 +532,7 @@
   display: flex;
   align-items: center;
   gap: $spacing-md;
+  min-width: 0;
 }
 
 .track-rank {
@@ -548,6 +549,7 @@
   align-items: center;
   gap: $spacing-md;
   flex: 1;
+  min-width: 0; // lets .track-name ellipsis engage instead of overflowing the column
   text-decoration: none;
   color: $text-primary;
   padding: $spacing-sm $spacing-md;


### PR DESCRIPTION
Long titles overflowed the Top Tracks column into Top Artists. `.track-link` was `flex:1` with no `min-width:0`, so it grew to content width and the `.track-name` ellipsis never engaged. Added `min-width:0` to `.track-item`/`.track-link` on Now + Wrapped. Verified: long titles now truncate, nothing bleeds past the column edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)