### PR TITLE
Music: track/artist detail modal (Open in Spotify / Xomify)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { MusicWrappedComponent } from './components/music-wrapped/music-wrapped.
 import { AppNavComponent } from './components/nav/app-nav.component';
 import { NowPlayingComponent } from './components/now-playing/now-playing.component';
 import { MusicSnapshotComponent } from './components/music-snapshot/music-snapshot.component';
+import { MusicDetailModalComponent } from './components/music-detail-modal/music-detail-modal.component';
 
 @NgModule({
   declarations: [
@@ -55,6 +56,7 @@ import { MusicSnapshotComponent } from './components/music-snapshot/music-snapsh
     AppNavComponent,
     NowPlayingComponent,
     MusicSnapshotComponent,
+    MusicDetailModalComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/music-detail-modal/music-detail-modal.component.html
+++ b/src/app/components/music-detail-modal/music-detail-modal.component.html
@@ -1,0 +1,74 @@
+<div
+  *ngIf="item"
+  class="detail-modal-backdrop"
+  role="dialog"
+  aria-modal="true"
+  [attr.aria-labelledby]="'detail-modal-title'"
+  (click)="onBackdropClick($event)"
+>
+  <div class="detail-modal-card">
+    <!-- Close button -->
+    <button
+      #focusable
+      type="button"
+      class="detail-modal-close"
+      aria-label="Close"
+      (click)="dismiss()"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" fill="currentColor"/>
+      </svg>
+    </button>
+
+    <!-- Hero image -->
+    <div class="detail-modal-image-wrap" [class.detail-modal-image-wrap--artist]="item.kind === 'artist'">
+      <img
+        [src]="item.image"
+        [alt]="item.kind === 'track' ? item.name + ' album art' : item.name + ' artist photo'"
+        class="detail-modal-image"
+      />
+    </div>
+
+    <!-- Text -->
+    <div class="detail-modal-text">
+      <p class="detail-modal-kind">{{ item.kind === 'track' ? 'Track' : 'Artist' }}</p>
+      <h2 id="detail-modal-title" class="detail-modal-name">{{ item.name }}</h2>
+      <p *ngIf="item.subtitle" class="detail-modal-subtitle">{{ item.subtitle }}</p>
+    </div>
+
+    <!-- Actions -->
+    <div class="detail-modal-actions">
+      <!-- Open in Spotify — always shown -->
+      <a
+        #focusable
+        [href]="item.spotifyUrl"
+        target="_blank"
+        rel="noopener"
+        class="detail-modal-btn detail-modal-btn--spotify"
+        [attr.aria-label]="'Open ' + item.name + ' on Spotify'"
+      >
+        <!-- Spotify glyph -->
+        <svg viewBox="0 0 24 24" class="detail-modal-btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" fill="currentColor"/>
+        </svg>
+        Open in Spotify
+      </a>
+
+      <!-- Open in Xomify — artists only -->
+      <a
+        #focusable
+        *ngIf="item.kind === 'artist' && xomifyArtistUrl"
+        [href]="xomifyArtistUrl"
+        target="_blank"
+        rel="noopener"
+        class="detail-modal-btn detail-modal-btn--xomify"
+        [attr.aria-label]="'Open ' + item.name + ' in Xomify'"
+      >
+        <svg viewBox="0 0 24 24" class="detail-modal-btn-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/>
+        </svg>
+        Open in Xomify
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/components/music-detail-modal/music-detail-modal.component.scss
+++ b/src/app/components/music-detail-modal/music-detail-modal.component.scss
@@ -1,0 +1,240 @@
+@import 'styles/variables';
+
+// ── Backdrop ────────────────────────────────────────────────────────────────
+.detail-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 20, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-md;
+  z-index: 1100;
+  animation: detail-modal-fade-in 0.2s ease-out;
+}
+
+@keyframes detail-modal-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes detail-modal-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .detail-modal-backdrop {
+    animation: none;
+  }
+
+  .detail-modal-card {
+    animation: none !important;
+  }
+}
+
+// ── Card ─────────────────────────────────────────────────────────────────────
+.detail-modal-card {
+  position: relative;
+  width: 100%;
+  max-width: 380px;
+  background: $card-gradient;
+  border: 1px solid $glass-border;
+  border-radius: $radius-xl;
+  box-shadow: $shadow-lg, $shadow-glow-cyan;
+  padding: $spacing-xl;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-lg;
+  animation: detail-modal-slide-up 0.25s $transition-spring forwards;
+
+  @media (max-width: $breakpoint-sm) {
+    max-width: 100%;
+    padding: $spacing-lg;
+    border-radius: $radius-lg;
+    gap: $spacing-md;
+  }
+}
+
+// ── Close button ─────────────────────────────────────────────────────────────
+.detail-modal-close {
+  position: absolute;
+  top: $spacing-md;
+  right: $spacing-md;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: $radius-sm;
+  color: $text-secondary;
+  cursor: pointer;
+  transition: color $transition-fast, background $transition-fast, border-color $transition-fast;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(255, 255, 255, 0.06);
+    border-color: $glass-border;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
+    border-radius: $radius-sm;
+  }
+}
+
+// ── Hero image ────────────────────────────────────────────────────────────────
+.detail-modal-image-wrap {
+  width: 160px;
+  height: 160px;
+  border-radius: $radius-lg;
+  overflow: hidden;
+  border: 1px solid $glass-border;
+  box-shadow: $shadow-md;
+  flex-shrink: 0;
+
+  // Artist images use a circle
+  &--artist {
+    border-radius: 50%;
+    box-shadow: $shadow-md, $shadow-glow-cyan;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    width: 128px;
+    height: 128px;
+  }
+}
+
+.detail-modal-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+// ── Text ─────────────────────────────────────────────────────────────────────
+.detail-modal-text {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-xs;
+  width: 100%;
+}
+
+.detail-modal-kind {
+  font-size: 11px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: $brand-cyan;
+  margin: 0;
+}
+
+.detail-modal-name {
+  font-size: 20px;
+  font-weight: $font-weight-bold;
+  color: $text-primary;
+  margin: 0;
+  line-height: 1.2;
+  // Long names should wrap, not truncate — this is the detail view
+  word-break: break-word;
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 18px;
+  }
+}
+
+.detail-modal-subtitle {
+  font-size: 14px;
+  color: $text-secondary;
+  margin: 0;
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+.detail-modal-actions {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+  width: 100%;
+}
+
+.detail-modal-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-sm;
+  width: 100%;
+  padding: $spacing-sm $spacing-xl;
+  border-radius: $radius-md;
+  font-size: 14px;
+  font-weight: $font-weight-semibold;
+  font-family: $font-stack;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background $transition-fast, transform $transition-fast, box-shadow $transition-fast;
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 3px;
+  }
+
+  &--spotify {
+    background: #1db954;
+    color: #fff;
+
+    &:hover {
+      background: #1ed760;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(29, 185, 84, 0.4);
+    }
+
+    &:focus-visible {
+      outline-color: #1db954;
+    }
+  }
+
+  &--xomify {
+    background: transparent;
+    color: $brand-cyan;
+    border: 1px solid rgba($brand-cyan, 0.4);
+
+    &:hover {
+      background: $brand-cyan-subtle;
+      border-color: rgba($brand-cyan, 0.7);
+      transform: translateY(-1px);
+    }
+  }
+}
+
+.detail-modal-btn-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}

--- a/src/app/components/music-detail-modal/music-detail-modal.component.ts
+++ b/src/app/components/music-detail-modal/music-detail-modal.component.ts
@@ -1,0 +1,134 @@
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  QueryList,
+  SimpleChanges,
+  ViewChildren,
+} from '@angular/core';
+import { MusicDetailItem } from '../../models/music.model';
+import { environment } from '../../../environments/environment';
+
+const XOMIFY_WEB_URL = environment.xomifyWebUrl;
+
+/** Extracts the Spotify entity ID from an open.spotify.com URL.
+ *  E.g. "https://open.spotify.com/artist/4q3ewBCX7sLwd24euuV69X" → "4q3ewBCX7sLwd24euuV69X"
+ *  Returns null if the URL doesn't match the expected pattern.
+ */
+function extractSpotifyId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.includes('spotify.com')) return null;
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+@Component({
+  selector: 'app-music-detail-modal',
+  templateUrl: './music-detail-modal.component.html',
+  styleUrls: ['./music-detail-modal.component.scss'],
+})
+export class MusicDetailModalComponent implements OnChanges, OnDestroy {
+  @Input() item: MusicDetailItem | null = null;
+  @Output() readonly close = new EventEmitter<void>();
+
+  /** All focusable interactive elements inside the dialog — used for tab-trap. */
+  @ViewChildren('focusable') focusableEls!: QueryList<ElementRef<HTMLElement>>;
+
+  /** The element that had focus when the modal opened — restored on close. */
+  private triggerEl: HTMLElement | null = null;
+
+  get xomifyArtistUrl(): string | null {
+    if (!this.item || this.item.kind !== 'artist') return null;
+    const id = extractSpotifyId(this.item.spotifyUrl);
+    if (!id) return null;
+    return `${XOMIFY_WEB_URL}/artist-profile/${id}`;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes['item']) return;
+
+    const opened = changes['item'].currentValue !== null;
+    const closed = changes['item'].currentValue === null;
+
+    if (opened) {
+      this.triggerEl = document.activeElement as HTMLElement | null;
+      document.body.style.overflow = 'hidden';
+      // Defer focus to after the view is rendered.
+      requestAnimationFrame(() => this.focusFirst());
+    }
+
+    if (closed) {
+      document.body.style.overflow = '';
+      this.triggerEl?.focus();
+      this.triggerEl = null;
+    }
+  }
+
+  ngOnDestroy(): void {
+    // Safety: restore scroll if the component is destroyed while open.
+    document.body.style.overflow = '';
+  }
+
+  dismiss(): void {
+    this.close.emit();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    // Only close when clicking the backdrop itself, not the card.
+    if (event.target === event.currentTarget) {
+      this.dismiss();
+    }
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    if (!this.item) return;
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.dismiss();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      this.trapFocus(event);
+    }
+  }
+
+  private focusFirst(): void {
+    const els = this.focusableEls?.toArray();
+    if (els?.length) {
+      els[0].nativeElement.focus();
+    }
+  }
+
+  private trapFocus(event: KeyboardEvent): void {
+    const els = this.focusableEls?.toArray().map((r) => r.nativeElement) ?? [];
+    if (els.length === 0) return;
+
+    const first = els[0];
+    const last = els[els.length - 1];
+    const focused = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (focused === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (focused === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  }
+}

--- a/src/app/components/music-wrapped/music-wrapped.component.html
+++ b/src/app/components/music-wrapped/music-wrapped.component.html
@@ -94,12 +94,11 @@
             class="track-item"
           >
             <span class="track-rank" aria-hidden="true">{{ i + 1 }}</span>
-            <a
-              [href]="track.url"
-              target="_blank"
-              rel="noopener"
+            <button
+              type="button"
               class="track-link"
-              [attr.aria-label]="track.name + ' by ' + track.artist + ' — open on Spotify'"
+              [attr.aria-label]="track.name + ' by ' + track.artist + ' — view details'"
+              (click)="openDetail({ kind: 'track', name: track.name, subtitle: track.artist, image: track.albumArt, spotifyUrl: track.url })"
             >
               <img
                 [src]="track.albumArt"
@@ -111,10 +110,10 @@
                 <span class="track-name">{{ track.name }}</span>
                 <span class="track-artist">{{ track.artist }}</span>
               </span>
-              <svg viewBox="0 0 24 24" class="track-ext-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="currentColor"/>
+              <svg viewBox="0 0 24 24" class="track-chevron-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor"/>
               </svg>
-            </a>
+            </button>
           </li>
         </ol>
       </section>
@@ -131,12 +130,11 @@
             class="artist-item"
           >
             <span class="artist-rank" aria-hidden="true">{{ i + 1 }}</span>
-            <a
-              [href]="artist.url"
-              target="_blank"
-              rel="noopener"
+            <button
+              type="button"
               class="artist-link"
-              [attr.aria-label]="artist.name + ' — open on Spotify'"
+              [attr.aria-label]="artist.name + ' — view details'"
+              (click)="openDetail({ kind: 'artist', name: artist.name, subtitle: 'Artist', image: artist.image, spotifyUrl: artist.url })"
             >
               <img
                 [src]="artist.image"
@@ -145,10 +143,10 @@
                 loading="lazy"
               />
               <span class="artist-name">{{ artist.name }}</span>
-              <svg viewBox="0 0 24 24" class="track-ext-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="currentColor"/>
+              <svg viewBox="0 0 24 24" class="track-chevron-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor"/>
               </svg>
-            </a>
+            </button>
           </li>
         </ol>
       </section>
@@ -190,3 +188,9 @@
     </div><!-- /.wrapped-columns -->
   </ng-container>
 </ng-container>
+
+<!-- Detail modal -->
+<app-music-detail-modal
+  [item]="detailItem"
+  (close)="detailItem = null"
+></app-music-detail-modal>

--- a/src/app/components/music-wrapped/music-wrapped.component.scss
+++ b/src/app/components/music-wrapped/music-wrapped.component.scss
@@ -354,6 +354,11 @@
   min-width: 0; // lets .track-name ellipsis engage instead of overflowing the column
   text-decoration: none;
   color: $text-primary;
+  background: none;
+  border: none;
+  font-family: $font-stack;
+  cursor: pointer;
+  text-align: left;
   padding: $spacing-sm $spacing-md;
   border-radius: $radius-md;
   transition: background $transition-fast, color $transition-fast;
@@ -362,7 +367,7 @@
     background: $bg-card;
     color: $brand-cyan-light;
 
-    .track-ext-icon {
+    .track-chevron-icon {
       opacity: 1;
     }
   }
@@ -414,6 +419,15 @@
   transition: opacity $transition-fast;
 }
 
+.track-chevron-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0;
+  color: $text-muted;
+  flex-shrink: 0;
+  transition: opacity $transition-fast;
+}
+
 // ── Artists list (mirrors music.component.scss) ───────
 .artists-list {
   list-style: none;
@@ -446,6 +460,11 @@
   flex: 1;
   text-decoration: none;
   color: $text-primary;
+  background: none;
+  border: none;
+  font-family: $font-stack;
+  cursor: pointer;
+  text-align: left;
   padding: $spacing-sm $spacing-md;
   border-radius: $radius-md;
   transition: background $transition-fast, color $transition-fast;
@@ -454,7 +473,7 @@
     background: $bg-card;
     color: $brand-cyan-light;
 
-    .track-ext-icon {
+    .track-chevron-icon {
       opacity: 1;
     }
   }

--- a/src/app/components/music-wrapped/music-wrapped.component.ts
+++ b/src/app/components/music-wrapped/music-wrapped.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { TopArtist, TopGenre, TopTrack } from '../../models/music.model';
+import { MusicDetailItem, TopArtist, TopGenre, TopTrack } from '../../models/music.model';
 import { WrappedArchive, WrappedMonth } from '../../models/wrapped.model';
 import { WrappedService } from '../../services/wrapped.service';
 
@@ -17,6 +17,9 @@ export class MusicWrappedComponent implements OnInit, OnDestroy {
   archive: WrappedArchive | null = null;
   selectedMonthKey = '';
   errorMessage = '';
+
+  // ── Detail modal ───────────────────────────────────
+  detailItem: MusicDetailItem | null = null;
 
   private sub?: Subscription;
 
@@ -83,6 +86,12 @@ export class MusicWrappedComponent implements OnInit, OnDestroy {
 
   trackByGenre(_index: number, genre: TopGenre): string {
     return genre.genre;
+  }
+
+  // ── Detail modal ───────────────────────────────────
+
+  openDetail(item: MusicDetailItem): void {
+    this.detailItem = item;
   }
 
   /** Returns a human-readable relative time string for the given ISO date. */

--- a/src/app/components/music/music.component.html
+++ b/src/app/components/music/music.component.html
@@ -190,12 +190,11 @@
           <ol class="tracks-list" *ngIf="profile.topTracks.length > 0">
             <li *ngFor="let track of profile.topTracks; let i = index" class="track-item">
               <span class="track-rank" aria-hidden="true">{{ i + 1 }}</span>
-              <a
-                [href]="track.url"
-                target="_blank"
-                rel="noopener"
+              <button
+                type="button"
                 class="track-link"
-                [attr.aria-label]="track.name + ' by ' + track.artist + ' — open on Spotify'"
+                [attr.aria-label]="track.name + ' by ' + track.artist + ' — view details'"
+                (click)="openDetail({ kind: 'track', name: track.name, subtitle: track.artist, image: track.albumArt, spotifyUrl: track.url })"
               >
                 <img
                   [src]="track.albumArt"
@@ -207,10 +206,10 @@
                   <span class="track-name">{{ track.name }}</span>
                   <span class="track-artist">{{ track.artist }}</span>
                 </span>
-                <svg viewBox="0 0 24 24" class="track-ext-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="currentColor"/>
+                <svg viewBox="0 0 24 24" class="track-chevron-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor"/>
                 </svg>
-              </a>
+              </button>
             </li>
           </ol>
         </section>
@@ -224,12 +223,11 @@
           <ol class="artists-list" *ngIf="profile.topArtists.length > 0">
             <li *ngFor="let artist of profile.topArtists; let i = index" class="artist-item">
               <span class="artist-rank" aria-hidden="true">{{ i + 1 }}</span>
-              <a
-                [href]="artist.url"
-                target="_blank"
-                rel="noopener"
+              <button
+                type="button"
                 class="artist-link"
-                [attr.aria-label]="artist.name + ' — open on Spotify'"
+                [attr.aria-label]="artist.name + ' — view details'"
+                (click)="openDetail({ kind: 'artist', name: artist.name, subtitle: 'Artist', image: artist.image, spotifyUrl: artist.url })"
               >
                 <img
                   [src]="artist.image"
@@ -238,10 +236,10 @@
                   loading="lazy"
                 />
                 <span class="artist-name">{{ artist.name }}</span>
-                <svg viewBox="0 0 24 24" class="track-ext-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="currentColor"/>
+                <svg viewBox="0 0 24 24" class="track-chevron-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor"/>
                 </svg>
-              </a>
+              </button>
             </li>
           </ol>
         </section>
@@ -309,6 +307,12 @@
   >
     <app-music-wrapped></app-music-wrapped>
   </div>
+
+  <!-- Detail modal -->
+  <app-music-detail-modal
+    [item]="detailItem"
+    (close)="detailItem = null"
+  ></app-music-detail-modal>
 
   <!-- Footer -->
   <footer class="music-footer">

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -552,6 +552,11 @@
   min-width: 0; // lets .track-name ellipsis engage instead of overflowing the column
   text-decoration: none;
   color: $text-primary;
+  background: none;
+  border: none;
+  font-family: $font-stack;
+  cursor: pointer;
+  text-align: left;
   padding: $spacing-sm $spacing-md;
   border-radius: $radius-md;
   transition: background $transition-fast, color $transition-fast;
@@ -560,7 +565,7 @@
     background: $bg-card;
     color: $brand-cyan-light;
 
-    .track-ext-icon {
+    .track-chevron-icon {
       opacity: 1;
     }
   }
@@ -612,6 +617,15 @@
   transition: opacity $transition-fast;
 }
 
+.track-chevron-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0;
+  color: $text-muted;
+  flex-shrink: 0;
+  transition: opacity $transition-fast;
+}
+
 // ── Artists list ─────────────────────────────────────
 .artists-list {
   list-style: none;
@@ -644,6 +658,11 @@
   flex: 1;
   text-decoration: none;
   color: $text-primary;
+  background: none;
+  border: none;
+  font-family: $font-stack;
+  cursor: pointer;
+  text-align: left;
   padding: $spacing-sm $spacing-md;
   border-radius: $radius-md;
   transition: background $transition-fast, color $transition-fast;
@@ -652,7 +671,7 @@
     background: $bg-card;
     color: $brand-cyan-light;
 
-    .track-ext-icon {
+    .track-chevron-icon {
       opacity: 1;
     }
   }

--- a/src/app/components/music/music.component.ts
+++ b/src/app/components/music/music.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { MusicProfile, MusicRange } from '../../models/music.model';
+import { MusicDetailItem, MusicProfile, MusicRange } from '../../models/music.model';
 import { MusicService } from '../../services/music.service';
 
 type LoadState = 'loading' | 'loaded' | 'error';
@@ -30,6 +30,9 @@ export class MusicComponent implements OnInit, OnDestroy {
   state: LoadState = 'loading';
   profile: MusicProfile | null = null;
   errorMessage = '';
+
+  // ── Detail modal ───────────────────────────────────
+  detailItem: MusicDetailItem | null = null;
 
   // ── Time-range switcher ────────────────────────────
   selectedRange: MusicRange = 'short_term';
@@ -142,6 +145,12 @@ export class MusicComponent implements OnInit, OnDestroy {
           this.rangeLoading = false;
         },
       });
+  }
+
+  // ── Detail modal ───────────────────────────────────
+
+  openDetail(item: MusicDetailItem): void {
+    this.detailItem = item;
   }
 
   /** Returns a human-readable relative time string for the given ISO date. */

--- a/src/app/models/music.model.ts
+++ b/src/app/models/music.model.ts
@@ -21,6 +21,14 @@ export interface TopGenre {
 /** Stub kept for ticker component input compatibility. */
 export interface NowPlaying {}
 
+export interface MusicDetailItem {
+  kind: 'track' | 'artist';
+  name: string;
+  subtitle: string | null;
+  image: string;
+  spotifyUrl: string;
+}
+
 export interface MusicProfile {
   topTracks: TopTrack[];
   topArtists: TopArtist[];

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,6 +10,7 @@ export const environment = {
   cognitoDomain: 'xomware-auth.auth.us-east-1.amazoncognito.com',
   ga4MeasurementId: '',
   musicProfileUserId: '12146721999',
+  xomifyWebUrl: 'https://xomify.xomware.com',
   musicSurfaces: {
     now: 'live',
     radar: 'live',


### PR DESCRIPTION
Click a track or artist (Now + Wrapped) → accessible detail modal (focus trap, Esc, backdrop close, scroll-lock) with **Open in Spotify** (both) and **Open in Xomify** (artists → `/artist-profile/:id`). Genres non-clickable; no in-app playback (per the public-page constraints we discussed). Frontend-only.

Verified via headless render: track modal (Spotify only), artist modal (Spotify + correct Xomify deep-link), Esc closes, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)