### PR TITLE
feat(landing): pin Xomforms AppCard

### DIFF
--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -137,6 +137,17 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
       platform: 'web',
     },
     {
+      name: 'Xomforms',
+      description: 'Group availability scheduler — When2meet done right. Drag-paint your availability, see the best time instantly.',
+      color: '#4caf50',
+      colorRgb: '76, 175, 80',
+      url: 'https://xomforms.xomware.com',
+      logo: 'assets/img/xomforms-placeholder.svg',
+      tag: 'Web App',
+      status: 'live',
+      platform: 'web',
+    },
+    {
       name: 'Xomify',
       description: 'Your Spotify stats on iOS. Native app available on TestFlight.',
       color: '#9c0abf',

--- a/src/assets/img/xomforms-placeholder.svg
+++ b/src/assets/img/xomforms-placeholder.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96">
+  <defs>
+    <linearGradient id="xomforms-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a2e0d"/>
+      <stop offset="100%" stop-color="#0a140a"/>
+    </linearGradient>
+    <linearGradient id="xomforms-green" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4caf50"/>
+      <stop offset="100%" stop-color="#388e3c"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background rounded rect -->
+  <rect width="96" height="96" rx="20" fill="url(#xomforms-bg)"/>
+
+  <!-- Calendar/grid outline -->
+  <rect x="20" y="24" width="56" height="48" rx="6" fill="none" stroke="url(#xomforms-green)" stroke-width="4"/>
+  <line x1="20" y1="38" x2="76" y2="38" stroke="url(#xomforms-green)" stroke-width="4"/>
+
+  <!-- Painted availability cells -->
+  <rect x="27" y="45" width="11" height="9" rx="2" fill="url(#xomforms-green)"/>
+  <rect x="42.5" y="45" width="11" height="9" rx="2" fill="url(#xomforms-green)" opacity="0.55"/>
+  <rect x="58" y="45" width="11" height="9" rx="2" fill="url(#xomforms-green)" opacity="0.3"/>
+  <rect x="27" y="58" width="11" height="9" rx="2" fill="url(#xomforms-green)" opacity="0.3"/>
+  <rect x="42.5" y="58" width="11" height="9" rx="2" fill="url(#xomforms-green)"/>
+  <rect x="58" y="58" width="11" height="9" rx="2" fill="url(#xomforms-green)" opacity="0.55"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds the Xomforms AppCard to the landing page `apps[]` array (web apps section), pointing at `https://xomforms.xomware.com` (live as of Phase 2 infra + Phase 3 frontend deploy).
- New placeholder SVG logo (`xomforms-placeholder.svg`), matching the existing `float-placeholder.svg` pattern -- no real logo asset exists yet.

## STOP POINT -- do not auto-merge
xomware-frontend is the live public homepage. Flagging this PR for Dom to review and merge manually rather than merging it myself.

## Test plan
- [x] `ng build --configuration production` clean, diff is exactly the intended AppCard addition (11 lines) + new SVG.