### PR TITLE
Space "Xom Forms" hub card name to match the wordmark

### DIFF
--- a/src/app/data/apps.data.ts
+++ b/src/app/data/apps.data.ts
@@ -79,7 +79,7 @@ export const APPS: AppCard[] = [
     platform: 'web',
   },
   {
-    name: 'Xomforms',
+    name: 'Xom Forms',
     description: 'Group availability scheduler — When2meet done right. Drag-paint your availability, see the best time instantly.',
     color: '#4caf50',
     colorRgb: '76, 175, 80',


### PR DESCRIPTION
## What
Renames the Xomforms app-directory card from `Xomforms` → `Xom Forms` in `src/app/data/apps.data.ts`, so the card name matches the two-word wordmark ("XOM FORMS") and the existing `Xom Appétit` spacing convention.

## Heads up — no "Xomtracks" in the data
The task also asked to space `Xomtracks` → `Xom Tracks`, but **there is no `Xomtracks` app in `apps.data.ts`** (searched the whole repo). The music/SoundCloud app is named **`XomCloud`**. I did not rename `XomCloud` — that would be a rebrand, not a spacing fix, and the instructions said not to touch other apps unless obviously wrong. Let me know if `XomCloud` should become `Xom Tracks` (or if `Xomtracks` is a new app to add) and I'll do it in a follow-up.

## Verification
- `ng build --configuration production` — clean.

⚠️ This is the live homepage — please review; do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNWkYn2EdScNmUsCbsn51k