### PR TITLE
Hub: 'Xom Tracks' name spacing

### DIFF
--- a/src/app/data/apps.data.ts
+++ b/src/app/data/apps.data.ts
@@ -91,7 +91,7 @@ export const APPS: AppCard[] = [
     platform: 'web',
   },
   {
-    name: 'Xomtracks',
+    name: 'Xom Tracks',
     description: 'Every song your group shares across iMessage — Spotify, SoundCloud & Apple Music — in one cover-art feed.',
     color: '#ff3750',
     colorRgb: '255, 55, 80',


### PR DESCRIPTION
Space the Xomtracks card name to match the wordmark.