### PR TITLE
Point Xomtracks hub CTA at renamed /shares route

### DIFF
--- a/src/app/components/music-xomtracks/music-xomtracks.component.ts
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.ts
@@ -29,9 +29,11 @@ export class MusicXomtracksComponent implements OnInit, OnDestroy {
   errorMessage = '';
 
   readonly xomifyUrl = environment.xomifyWebUrl;
-  // Deep-links straight to the Xomtracks feature inside xomify (the full,
-  // sortable feed + ratings), not just the xomify app root.
-  readonly xomtracksFeatureUrl = `${environment.xomifyWebUrl}/xomtracks`;
+  // Deep-links straight to the Xomtracks (Shares) feature inside xomify (the
+  // full, sortable feed + ratings), not just the xomify app root. The route
+  // itself was renamed from /xomtracks to /shares; xomify still redirects
+  // the old path, but point at the canonical one here.
+  readonly xomtracksFeatureUrl = `${environment.xomifyWebUrl}/shares`;
   readonly playlists: PlaylistLink[] = [
     { label: 'Shared With Me — Rolling Playlist', url: environment.xomtracksPlaylists.in },
     { label: 'Shared By Me — Rolling Playlist', url: environment.xomtracksPlaylists.out },


### PR DESCRIPTION
## Summary
- xomify renamed the Shares feature's route from `/xomtracks` to `/shares` (see companion PR in xomify-frontend). Updates the hub's "View more in Xomify" CTA to point at the new canonical URL.

## Changes
- `music-xomtracks.component.ts` — `xomtracksFeatureUrl` now builds `${environment.xomifyWebUrl}/shares` instead of `/xomtracks`

Note: the `xomtracks.xomware.com` URL in `apps.data.ts` is a separate standalone app-directory card, not the xomify sub-route, so it was left untouched — out of scope for this rename.

## Test plan
- [x] `npm run build:prod` — green
- [x] `npm test` (Karma/ChromeHeadless) — green
- [ ] Manual: confirm hub's "View more in Xomify" CTA opens `xomify.xomware.com/shares`