### PR TITLE
Music hub: rename Xomtracks sub-tab to Shares

### DIFF
--- a/src/app/components/music-xomtracks/music-xomtracks.component.html
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.html
@@ -1,18 +1,18 @@
 <!-- Coming soon state -->
-<div class="xomtracks-coming-soon" *ngIf="state === 'coming-soon'" aria-label="Xomtracks showcase coming soon">
+<div class="xomtracks-coming-soon" *ngIf="state === 'coming-soon'" aria-label="Shares showcase coming soon">
   <div class="xomtracks-coming-soon-inner">
     <svg viewBox="0 0 24 24" class="xomtracks-coming-soon-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
       <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z" fill="currentColor"/>
     </svg>
-    <h2 class="xomtracks-coming-soon-title">Xomtracks is coming soon</h2>
+    <h2 class="xomtracks-coming-soon-title">Shares is coming soon</h2>
     <p class="xomtracks-coming-soon-body">
-      Every song shared across Dom's group chats, tracked in one feed — powered by Xomtracks.
+      Every song shared across Dom's group chats, tracked in one feed — powered by Shares.
     </p>
   </div>
 </div>
 
 <!-- Loading state -->
-<div class="xomtracks-loading" *ngIf="state === 'loading'" aria-live="polite" aria-label="Loading Xomtracks showcase">
+<div class="xomtracks-loading" *ngIf="state === 'loading'" aria-live="polite" aria-label="Loading Shares showcase">
   <div class="skeleton-columns">
     <div class="skeleton-section">
       <div class="skeleton skeleton-heading"></div>

--- a/src/app/components/music-xomtracks/music-xomtracks.component.ts
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.ts
@@ -67,7 +67,7 @@ export class MusicXomtracksComponent implements OnInit, OnDestroy {
       },
       error: () => {
         this.errorMessage =
-          'Could not load the Xomtracks showcase. The backend may be unavailable.';
+          'Could not load the Shares showcase. The backend may be unavailable.';
         this.state = 'error';
       },
     });

--- a/src/app/components/music/music.component.html
+++ b/src/app/components/music/music.component.html
@@ -104,7 +104,7 @@
         <svg viewBox="0 0 24 24" class="music-tab-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
           <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z" fill="currentColor"/>
         </svg>
-        Xomtracks
+        Shares
       </button>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- Renamed all **user-facing** text/aria-labels on the `/music` hub's Xomtracks sub-tab from "Xomtracks" to "Shares" (Dom's shared-music section): tab label, coming-soon heading/body, loading aria-label, error message.
- Internal names left untouched to minimize churn: `MusicXomtracksComponent`, `music-xomtracks/`, `XomtracksShowcaseService`, `xomtracks-*` CSS classes, the `MusicTab` `'xomtracks'` literal, and the `?tab=xomtracks` query param.
- **Investigated the "stuck on coming soon" report — does not reproduce.** `environment.musicSurfaces.xomtracks` has been `'live'` since the sub-tab was first added (PR #148); `xomtracksOwnerId` is correctly set to `dominickj.giordano@gmail.com`; the service correctly unwraps the `{data,error,meta}` envelope. Confirmed with a headless-browser pass against the live production bundle (both via direct `?tab=xomtracks` URL and by clicking the tab from `/music`): the section renders real `sharedWithMe`/`sharedByMe` data, no coming-soon/error state. No code change was needed for the load behavior — only the copy rename above.

## Test plan
- [x] `npm run build:prod` — clean build
- [x] `npm test` — 1/1 passing (only existing spec, `app.component.spec.ts`; this component has no dedicated specs)
- [x] Headless-browser check against `https://xomware.com/music?tab=xomtracks` and via clicking the tab — confirms live data renders correctly post-rename
- [ ] Dom: hard-refresh (or clear cache) on `xomware.com/music` and confirm the tab now reads "Shares" and shows real shares

🤖 Generated with [Claude Code](https://claude.com/claude-code)