### PR TITLE
Polish Shares showcase: drop playlist pills, link titles, fix genre overflow

### DIFF
--- a/src/app/components/music-snapshot/music-snapshot.component.scss
+++ b/src/app/components/music-snapshot/music-snapshot.component.scss
@@ -331,13 +331,15 @@
   align-items: center;
   gap: $spacing-sm;
   padding: 4px $spacing-sm;
+  min-width: 0;
 }
 
 .snapshot-genre-name {
   font-size: 13px;
   font-weight: $font-weight-medium;
   color: $text-primary;
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -347,6 +349,7 @@
 .snapshot-genre-count {
   font-size: 11px;
   color: $text-muted;
+  flex-shrink: 0;
   min-width: 20px;
   text-align: right;
 }

--- a/src/app/components/music-xomtracks/music-xomtracks.component.html
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.html
@@ -42,25 +42,6 @@
     Every song shared across Dom's group chats — Spotify, SoundCloud &amp; Apple Music, all in one feed.
   </p>
 
-  <!-- Playlist links -->
-  <nav class="xomtracks-playlists" aria-label="Rolling playlists">
-    <a
-      *ngFor="let playlist of playlists"
-      [href]="playlist.url"
-      target="_blank"
-      rel="noopener"
-      class="xomtracks-playlist-link"
-    >
-      <svg viewBox="0 0 24 24" class="xomtracks-playlist-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-        <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" fill="currentColor"/>
-      </svg>
-      <span class="xomtracks-playlist-label">{{ playlist.label }}</span>
-      <svg viewBox="0 0 24 24" class="xomtracks-playlist-ext-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-        <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="currentColor"/>
-      </svg>
-    </a>
-  </nav>
-
   <!-- Recent shares -->
   <div class="xomtracks-columns">
     <section class="xomtracks-section" aria-labelledby="xomtracks-with-me-heading">
@@ -83,7 +64,17 @@
             </svg>
           </span>
           <span class="share-info">
-            <span class="share-name">{{ displayTitle(share) }}</span>
+            <a
+              *ngIf="shareUrl(share) as url; else sharedWithMeTitle"
+              [href]="url"
+              target="_blank"
+              rel="noopener"
+              class="share-name share-name--link"
+              [attr.aria-label]="displayTitle(share) + ' — open on ' + platformLabel(share.platform)"
+            >{{ displayTitle(share) }}</a>
+            <ng-template #sharedWithMeTitle>
+              <span class="share-name">{{ displayTitle(share) }}</span>
+            </ng-template>
             <span class="share-artist">{{ displayArtist(share) }}</span>
             <span class="share-meta">from {{ displaySharer(share) }} &middot; {{ relativeTime(share.date) }}</span>
           </span>
@@ -114,7 +105,17 @@
             </svg>
           </span>
           <span class="share-info">
-            <span class="share-name">{{ displayTitle(share) }}</span>
+            <a
+              *ngIf="shareUrl(share) as url; else sharedByMeTitle"
+              [href]="url"
+              target="_blank"
+              rel="noopener"
+              class="share-name share-name--link"
+              [attr.aria-label]="displayTitle(share) + ' — open on ' + platformLabel(share.platform)"
+            >{{ displayTitle(share) }}</a>
+            <ng-template #sharedByMeTitle>
+              <span class="share-name">{{ displayTitle(share) }}</span>
+            </ng-template>
             <span class="share-artist">{{ displayArtist(share) }}</span>
             <span class="share-meta">{{ relativeTime(share.date) }}</span>
           </span>

--- a/src/app/components/music-xomtracks/music-xomtracks.component.scss
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.scss
@@ -155,67 +155,6 @@
   margin: 0 0 $spacing-lg;
 }
 
-// ── Playlist links ────────────────────────────────────
-.xomtracks-playlists {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-md;
-  margin-bottom: $spacing-2xl;
-}
-
-.xomtracks-playlist-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-sm;
-  padding: $spacing-sm $spacing-lg;
-  background: $bg-card;
-  border: 1px solid $glass-border;
-  border-radius: $radius-pill;
-  color: $text-primary;
-  text-decoration: none;
-  font-size: 13px;
-  font-weight: $font-weight-semibold;
-  transition:
-    background $transition-fast,
-    border-color $transition-fast,
-    transform $transition-fast;
-
-  &:hover {
-    background: rgba($xomtracks-red, 0.12);
-    border-color: rgba($xomtracks-red, 0.35);
-    transform: translateY(-1px);
-
-    .xomtracks-playlist-ext-icon {
-      opacity: 1;
-    }
-  }
-
-  &:active {
-    transform: translateY(0);
-  }
-
-  &:focus-visible {
-    outline: 2px solid $xomtracks-red;
-    outline-offset: 2px;
-  }
-}
-
-.xomtracks-playlist-icon {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-  color: $xomtracks-red;
-}
-
-.xomtracks-playlist-ext-icon {
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
-  color: $text-muted;
-  opacity: 0;
-  transition: opacity $transition-fast;
-}
-
 // ── Recent-shares columns ─────────────────────────────
 .xomtracks-columns {
   display: grid;
@@ -306,6 +245,23 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.share-name--link {
+  text-decoration: none;
+  transition: color $transition-fast;
+
+  &:hover,
+  &:focus-visible {
+    color: $xomtracks-red;
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $xomtracks-red;
+    outline-offset: 2px;
+    border-radius: $radius-sm;
+  }
 }
 
 .share-artist {

--- a/src/app/components/music-xomtracks/music-xomtracks.component.ts
+++ b/src/app/components/music-xomtracks/music-xomtracks.component.ts
@@ -6,11 +6,6 @@ import { XomtracksShowcaseService } from '../../services/xomtracks-showcase.serv
 
 type LoadState = 'loading' | 'loaded' | 'error' | 'coming-soon';
 
-interface PlaylistLink {
-  label: string;
-  url: string;
-}
-
 const PLATFORM_LABELS: Record<string, string> = {
   spotify: 'Spotify',
   soundcloud: 'SoundCloud',
@@ -34,10 +29,6 @@ export class MusicXomtracksComponent implements OnInit, OnDestroy {
   // itself was renamed from /xomtracks to /shares; xomify still redirects
   // the old path, but point at the canonical one here.
   readonly xomtracksFeatureUrl = `${environment.xomifyWebUrl}/shares`;
-  readonly playlists: PlaylistLink[] = [
-    { label: 'Shared With Me — Rolling Playlist', url: environment.xomtracksPlaylists.in },
-    { label: 'Shared By Me — Rolling Playlist', url: environment.xomtracksPlaylists.out },
-  ];
 
   private sub?: Subscription;
 
@@ -93,6 +84,23 @@ export class MusicXomtracksComponent implements OnInit, OnDestroy {
 
   platformLabel(platform: string): string {
     return PLATFORM_LABELS[platform] ?? platform;
+  }
+
+  /**
+   * Resolves the URL a share's title should link out to, or `null` if we
+   * don't have enough to build one (renders as plain text in that case).
+   * `/shares/recent` doesn't return a direct track URL as of writing —
+   * this prefers an explicit `url`/`sourceUrl` from the payload the moment
+   * the backend adds one, and falls back to deriving an open.spotify.com
+   * link from a Spotify track id if the platform is Spotify.
+   */
+  shareUrl(share: ShareCard): string | null {
+    if (share.url) return share.url;
+    if (share.sourceUrl) return share.sourceUrl;
+    if (share.platform === 'spotify' && share.spotifyId) {
+      return `https://open.spotify.com/track/${share.spotifyId}`;
+    }
+    return null;
   }
 
   /** Returns a human-readable relative time string for an epoch-seconds date. */

--- a/src/app/components/music/music.component.scss
+++ b/src/app/components/music/music.component.scss
@@ -713,13 +713,15 @@
   font-size: 15px;
   font-weight: $font-weight-medium;
   color: $text-primary;
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .genre-count {
   font-size: 12px;
   font-weight: $font-weight-medium;
   color: $text-muted;
+  flex-shrink: 0;
   min-width: 28px;
   text-align: right;
 }

--- a/src/app/models/xomtracks-showcase.model.ts
+++ b/src/app/models/xomtracks-showcase.model.ts
@@ -17,6 +17,17 @@ export interface ShareCard {
   direction: ShareDirection;
   /** Epoch seconds (source: messageDate). */
   date: number;
+  /**
+   * Direct link to the track on its source platform. Not yet returned by
+   * `/shares/recent` as of writing — modeled here (and its fallbacks below)
+   * so the hub showcase can link share titles the moment the backend adds
+   * one of these fields, without another frontend change.
+   */
+  url?: string | null;
+  /** Alternate field name some xomtracks-backend responses use for the above. */
+  sourceUrl?: string | null;
+  /** Spotify track id, if resolved — used to derive an open.spotify.com link when `url`/`sourceUrl` are absent. */
+  spotifyId?: string | null;
 }
 
 /** The `data` payload of the `/shares/recent` envelope response. */

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,13 +15,6 @@ export const environment = {
   // Explicit override for GET /shares/recent — see xomtracks-showcase.service.ts
   // for why this is passed instead of relying on the backend's default scoping.
   xomtracksOwnerId: 'dominickj.giordano@gmail.com',
-  // Rolling playlists have no listing API yet — static Spotify playlist URLs
-  // (ids are stable once created; only playlist *contents* roll weekly).
-  // Follow-up: xomtracks-backend could expose these via /shares/recent's meta.
-  xomtracksPlaylists: {
-    in: 'https://open.spotify.com/playlist/1EovEoa2MJO7tX4qPEvnsr',
-    out: 'https://open.spotify.com/playlist/12rO1QHPLvJ4L3Gehi7PPX',
-  },
   musicSurfaces: {
     now: 'live',
     radar: 'live',


### PR DESCRIPTION
## Summary
- Removes the two "Rolling Playlist" pill buttons (Shared With Me / Shared By Me) from the Shares showcase on the hub Music tab — dead weight with no listing API behind them.
- Each share title is now a clickable link (`target="_blank" rel="noopener"`) that opens the track on its source platform. `/shares/recent` doesn't return a track URL yet, so this prefers `url`/`sourceUrl` from the payload (modeled as optional fields on `ShareCard` for forward-compat) and derives an `open.spotify.com` link from a `spotifyId` if present; with none of those, the title renders as plain text instead of a dead link. Confirmed via a direct hit of the live endpoint that none of these fields exist today, so all current shares render as plain text until the backend adds one.
- Fixes the Top Genres count number (e.g. 85/79/55) clipping off the right edge of the Listening Snapshot card, and the same latent bug in the Now tab's genre list — both were missing `min-width: 0` on the genre name and `flex-shrink: 0` on the count inside the flex row.

Investigated a reported "Favorites" tab on the hub (item 3 in the original ask) — could not find any trace of it in this repo (no matches for "favorite"/"favourite" anywhere in `src/`, no route, no nav entry, no git history). It looks like a xomify-only feature; nothing changed here for it. Flagging back rather than guessing at a deletion.

## Test plan
- [x] `npm run build:prod` — clean build
- [x] `npm test -- --watch=false --browsers=ChromeHeadless` — green (repo only has 1 spec total, unaffected)
- [ ] Manual check at `/music?tab=xomtracks` (mobile + desktop) — pills gone, titles link out when a URL is present
- [ ] Manual check of the landing page Listening Snapshot card genre counts at narrow widths