### PR TITLE
Remove Shares app card, fix genre count clipping, widen snapshot card

### DIFF
--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -427,7 +427,7 @@
 // affect this element. Sits as its own in-flow block after the hero.
 .music-snapshot-section {
   width: 100%;
-  max-width: 720px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 0 $spacing-xl $spacing-3xl;
 

--- a/src/app/components/music-snapshot/music-snapshot.component.scss
+++ b/src/app/components/music-snapshot/music-snapshot.component.scss
@@ -2,7 +2,7 @@
 
 .snapshot {
   width: 100%;
-  max-width: 900px;
+  max-width: 1100px;
   margin: $spacing-3xl auto 0;
   padding: $spacing-xl;
   background: rgba(20, 20, 40, 0.5);
@@ -226,6 +226,17 @@
   }
 }
 
+// Grid items default to `min-width: auto`, which means they refuse to
+// shrink below their content's min-content size. Genre names use
+// `white-space: nowrap`, so a long name (e.g. "Future Bass") contributes
+// its full unwrapped width to that min-content calc — expanding this
+// column past its 1fr share and pushing the count off the card's edge.
+// `min-width: 0` overrides that so the ellipsis/flex rules below can
+// actually clip content within the column's real (1fr) width.
+.snapshot-col {
+  min-width: 0;
+}
+
 .snapshot-col-heading {
   font-size: 11px;
   font-weight: $font-weight-bold;
@@ -329,6 +340,7 @@
 .snapshot-genre-item {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: $spacing-sm;
   padding: 4px $spacing-sm;
   min-width: 0;

--- a/src/app/data/apps.data.ts
+++ b/src/app/data/apps.data.ts
@@ -91,18 +91,6 @@ export const APPS: AppCard[] = [
     platform: 'web',
   },
   {
-    name: 'Shares',
-    description: 'Every song your group shares across iMessage — Spotify, SoundCloud & Apple Music — in one cover-art feed. Now part of Xomify.',
-    color: '#ff3750',
-    colorRgb: '255, 55, 80',
-    url: 'https://xomify.xomware.com/shares',
-    logo: 'assets/img/xomtracks-banner.png',
-    logoStyle: 'banner',
-    tag: 'Web App',
-    status: 'live',
-    platform: 'web',
-  },
-  {
     name: 'Xomify',
     description: 'Your Spotify stats on iOS. Native app available on TestFlight.',
     color: '#9c0abf',


### PR DESCRIPTION
## Summary
- Remove the "Shares" (formerly Xomtracks) app-directory card entirely — Xomtracks folded into Xomify and is no longer a standalone app-directory entry.
- Fix Top Genres count clipping in the Listening Snapshot card. Root cause: `.snapshot-col` is a CSS Grid item (child of `grid-template-columns: repeat(3, 1fr)`) with no `min-width`, so it defaulted to `min-width: auto`. Genre names use `white-space: nowrap`, so a long name (e.g. "Future Bass") contributed its full unwrapped width to the column's min-content size, expanding the track past its `1fr` share and pushing the count off the card's right edge. A prior fix added `min-width: 0` on the name span (a flex child) but never on the grid item itself, so it didn't hold. Fixed by adding `min-width: 0` to `.snapshot-col`, plus `justify-content: space-between` on the row as a belt-and-suspenders layout guarantee.
- Widen the Listening Snapshot card from 720px (wrapper)/900px (component) to 1100px, matching the site's existing wide-content convention (same max-width used for the apps grid/footer), so it uses more of the viewport and the three columns get more room.

## Test plan
- [x] `npm run build:prod` — clean production build
- [x] `npx ng test --watch=false --browsers=ChromeHeadless` — passes (1/1)
- [ ] Visually verify on xomware.com: Shares card gone from `/apps` and landing grid, genre counts (2-3 digit) never clip even with long genre names, snapshot card visibly wider on desktop and still collapses correctly on mobile