### PR TITLE
feat(admin): surface Xomcron as an internal tool

### DIFF
--- a/src/app/components/admin/admin.component.html
+++ b/src/app/components/admin/admin.component.html
@@ -12,6 +12,29 @@
   </header>
 
   <main class="admin-content">
+    <!-- Internal tools — private apps kept off the public directory. -->
+    <section
+      class="internal-tools"
+      *ngIf="internalTools.length"
+      aria-labelledby="internal-tools-heading"
+    >
+      <h2 id="internal-tools-heading" class="internal-tools-heading">Internal tools</h2>
+      <div class="internal-tools-grid">
+        <a
+          class="internal-tool"
+          *ngFor="let tool of internalTools"
+          [href]="tool.url"
+          rel="noopener"
+        >
+          <img class="internal-tool-logo" [src]="tool.logo" [alt]="tool.name" />
+          <span class="internal-tool-body">
+            <span class="internal-tool-name">{{ tool.name }}</span>
+            <span class="internal-tool-desc">{{ tool.description }}</span>
+          </span>
+        </a>
+      </div>
+    </section>
+
     <div class="admin-grid">
       <!-- Events card -->
       <section class="card events-card" aria-labelledby="events-heading">

--- a/src/app/components/admin/admin.component.scss
+++ b/src/app/components/admin/admin.component.scss
@@ -81,6 +81,74 @@
   gap: $spacing-md;
 }
 
+// --- Internal tools ---
+.internal-tools {
+  max-width: 1100px;
+  margin: 0 auto $spacing-md;
+}
+
+.internal-tools-heading {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  margin: 0 0 $spacing-sm;
+}
+
+.internal-tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: $spacing-md;
+}
+
+.internal-tool {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: $card-gradient;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: $radius-lg;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.18);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+  }
+}
+
+.internal-tool-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.internal-tool-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.internal-tool-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.internal-tool-desc {
+  font-size: 0.8rem;
+  opacity: 0.6;
+  line-height: 1.4;
+}
+
 // --- Cards ---
 .card {
   background: $card-gradient;

--- a/src/app/components/admin/admin.component.ts
+++ b/src/app/components/admin/admin.component.ts
@@ -8,6 +8,7 @@ import {
   EventsListResponse,
 } from '../../services/admin.service';
 import { CognitoService } from '../../services/cognito.service';
+import { AppCard, APPS } from '../../data/apps.data';
 
 @Component({
   selector: 'app-admin',
@@ -27,6 +28,12 @@ export class AdminComponent implements OnInit {
   cost: CostSummaryResponse | null = null;
   costLoading = false;
   costError = '';
+
+  /**
+   * Internal tools, kept off the public directory. This route is already
+   * behind adminGuard, and each tool gates independently on its own API.
+   */
+  readonly internalTools: AppCard[] = APPS.filter((a) => a.adminOnly);
 
   constructor(
     private admin: AdminService,

--- a/src/app/components/apps/apps.component.ts
+++ b/src/app/components/apps/apps.component.ts
@@ -14,7 +14,9 @@ import { AppCard, APPS } from '../../data/apps.data';
   styleUrls: ['./apps.component.scss'],
 })
 export class AppsComponent {
-  apps: AppCard[] = APPS;
+  // This route is public, so internal tools must never reach it. Filtered at
+  // the source rather than per-getter so a future getter can't leak one.
+  apps: AppCard[] = APPS.filter((a) => !a.adminOnly);
 
   get webApps(): AppCard[] {
     return this.apps.filter((a) => a.platform === 'web');

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -32,8 +32,11 @@ export class LandingComponent implements AfterViewInit, OnDestroy, OnInit {
   landingTickerProfile: MusicProfile | null = null;
   nowPlayingState: NowPlayingState | null = null;
 
-  /** Full app directory — see src/app/data/apps.data.ts (shared with /apps). */
-  apps: AppCard[] = APPS;
+  /**
+   * Public app directory — see src/app/data/apps.data.ts (shared with /apps).
+   * Internal tools (`adminOnly`) are excluded; they surface in /admin only.
+   */
+  apps: AppCard[] = APPS.filter((a) => !a.adminOnly);
 
   private userSub?: Subscription;
   private tickerSub?: Subscription;

--- a/src/app/data/apps.data.ts
+++ b/src/app/data/apps.data.ts
@@ -15,6 +15,12 @@ export interface AppCard {
    * squashed into the default square icon slot. Omit for square icons.
    */
   logoStyle?: 'banner';
+  /**
+   * Internal tool — surfaced only inside the admin portal, never on the public
+   * /apps grid or the landing page. The app's own API is the real gate; this
+   * flag just keeps a private tool off a public directory.
+   */
+  adminOnly?: boolean;
 }
 
 /**
@@ -133,5 +139,17 @@ export const APPS: AppCard[] = [
     tag: 'iOS · Coming Soon',
     status: 'coming-soon',
     platform: 'ios',
+  },
+  {
+    name: 'Xomcron',
+    description: 'Scheduled tasks and trackers. Price watches, card credits, AWS spend.',
+    color: '#2563eb',
+    colorRgb: '37, 99, 235',
+    url: 'https://crons.xomware.com',
+    logo: 'assets/img/xomcron-logo.svg',
+    tag: 'Internal',
+    status: 'live',
+    platform: 'web',
+    adminOnly: true,
   },
 ];

--- a/src/assets/img/xomcron-logo.svg
+++ b/src/assets/img/xomcron-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Xomcron">
+  <rect width="64" height="64" rx="14" fill="#2563eb"/>
+  <circle cx="32" cy="32" r="17" fill="none" stroke="#ffffff" stroke-width="3.5"/>
+  <path d="M32 21v12l8 4.6" fill="none" stroke="#ffffff" stroke-width="3.5"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Xomcron (crons.xomware.com) went live but had no entry point from
xomware.com. This adds one, in the admin portal.

## Changes

- `AppCard` gains an optional `adminOnly` flag.
- Xomcron added to `apps.data.ts` with `adminOnly: true`.
- `/apps` and the landing grid filter internal tools **out** — both are
  public, unauthenticated routes.
- `/admin` (already behind `adminGuard`) gains an "Internal tools" section.
- New `xomcron-logo.svg`.

## Why filter at assignment

`apps` is filtered where it's assigned rather than inside `webApps`/`iosApps`,
so a getter added later can't leak an internal tool by forgetting the check.

## Note on gating

This flag is directory hygiene, not security. Xomcron's own API is the real
gate — it verifies a Cognito JWT and then requires the owner's `sub`, so a
non-owner who reaches the URL gets 403 on every endpoint.