### PR TITLE
Extract shared design tokens and propagate to four frontends

### DIFF
--- a/docs/features/ui-polish/EXECUTION_LOG.md
+++ b/docs/features/ui-polish/EXECUTION_LOG.md
@@ -113,6 +113,68 @@ product's actual identity. Changing it here would desync from the real app.
 
 ---
 
+## Final state (updated 2026-08-05, after PRs #155-161)
+
+**xomware-frontend is done.** Token violations 289 -> 0, enforced directly by
+stylelint (the ratchet was retired once the count hit zero). 23 visual baselines
+including hover. Merged and deployed across PRs #155, #156, #157, #158, #159,
+#160, #161.
+
+Everything in "Deliberately not done" below was subsequently completed except
+where noted. Kept for the record of what the risk calls were at the time.
+
+### Bugs found and fixed along the way
+1. **iOS double-tap** - every app card needed two taps to open, because :hover
+   was ungated on touch.
+2. **Mobile horizontal overflow** on /music?tab=xomtracks - 458px of content in
+   a 390px viewport. Mobile grid used `1fr` where desktop correctly used
+   `minmax(0, 1fr)`.
+3. **Faux-bold wordmark** - font-weight 900 with no 900 face loaded.
+
+### Corrections to RESEARCH.md
+The research doc was wrong in three places, all corrected inline and all found
+by reading the code rather than the CSS counts:
+- Per-app colour is hover-only; the grid is monochrome at rest (§3.3)
+- 400/500 weights were already in use via variables (§3.6)
+- "18 glows" conflated elevation shadows and focus rings; the real count is ~9 (§3.4)
+
+**Treat the original claims in RESEARCH.md with suspicion. The verified ones are
+marked CORRECTED.**
+
+### Visual-suite lessons
+- `maxDiffPixelRatio: 0.01` was far too coarse - 1% of a tall page is ~25,000
+  pixels, so glow removals and a heading losing its gradient passed silently.
+  Now an absolute `maxDiffPixels: 150`.
+- `dist/` is shared with `build:prod`, so a production build left the wrong
+  bundle in place and poisoned baselines. The suite now builds its own input.
+- An element screenshot clips to the border box and excludes `box-shadow`.
+
+---
+
+## Remaining work
+
+**The other 7 frontends still have no design tokens.** This is now the largest
+outstanding item and the one the research flagged as highest-leverage:
+
+| App | SCSS files | Distinct font sizes | Tokens |
+|---|---|---|---|
+| xomify-frontend | 81 | **64** | none |
+| xomper-front-end | 73 | 36 | own file, different contents |
+| xomforms-frontend | 22 | 36 | none |
+| xomcloud-frontend | 20 | 26 | own file, different path |
+| xomtracks-frontend | 16 | 38 | none |
+| xomcron-frontend | 11 | 11 | none |
+| vest-site | 5 | 8 | none |
+
+xomify is worse than xomware-frontend ever was.
+
+**Corner radius** (20-24px vs the reference's near-zero) is the one remaining
+identity decision, deliberately left for the owner.
+
+---
+
+## Original open items (kept for the record)
+
 ## Open items
 
 1. **Xom Forms vs XomFit green** — genuinely two green products. Accept, or

--- a/docs/features/ui-polish/EXECUTION_LOG.md
+++ b/docs/features/ui-polish/EXECUTION_LOG.md
@@ -168,8 +168,49 @@ outstanding item and the one the research flagged as highest-leverage:
 
 xomify is worse than xomware-frontend ever was.
 
-**Corner radius** (20-24px vs the reference's near-zero) is the one remaining
-identity decision, deliberately left for the owner.
+### Token propagation (done 2026-08-05)
+
+Shared tokens extracted to `src/styles/_tokens.scss` and adopted by four repos:
+
+| App | Substitutions | Tie fixes | PR |
+|---|---|---|---|
+| xomcron-frontend | 95 | 2 | #1 merged |
+| xomtracks-frontend | 237 | 0 | #9 merged |
+| xomforms-frontend | 391 | 3 | #25 merged |
+| xomify-frontend | — (81 files, 64 sizes) | 23 | #333 merged |
+
+All four now enforce the scale with stylelint in PR-time CI.
+
+### BLOCKED — needs a decision, not a migration
+
+`xomcloud-frontend` and `xomper-front-end` already define variables that collide
+with the shared token names **at different values**. Importing the shared file
+would silently reassign them app-wide:
+
+- **xomcloud**: `radius-sm` 8->4px, `radius-md` 12->8px, `radius-lg` 16->12px,
+  `radius-pill` 25->100px — every rounded corner in the app changes
+- **xomper**: `text-xs` 0.75->0.8125rem, `text-lg` 1.125->1.25rem, `text-xl`
+  1.25->1.5rem, `text-2xl` 1.5->1.625rem, `text-4xl` 2.5->2.375rem — text
+  resizes app-wide
+
+Neither has a visual regression suite, so nothing would catch the damage. Both
+already have internally coherent scales; the only gain from unifying is
+cross-app consistency, and the cost is resizing a live app blind. **Owner's
+call.**
+
+`vest-site` is not a consumer — its `main` branch holds only a README.
+
+### The tie trap, totalled
+
+`0.04em` sits exactly between `$tracking-normal` and `$tracking-wide`. Automatic
+nearest-match rounds it to 0 and silently strips tracking from uppercase labels.
+It hit **31 components across four repos**. It is now documented in
+`_tokens.scss` itself so the next migration does not repeat it.
+
+### Corner radius
+
+(20-24px vs the reference's near-zero) is the one remaining identity decision,
+deliberately left for the owner.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint:css": "stylelint \"src/**/*.scss\"",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
-    "build:visual": "ng build --configuration visual --output-hashing=none"
+    "build:visual": "ng build --configuration visual --output-hashing=none",
+    "tokens:check": "node scripts/sync-tokens.mjs",
+    "tokens:sync": "node scripts/sync-tokens.mjs --write"
   },
   "private": true,
   "dependencies": {

--- a/scripts/sync-tokens.mjs
+++ b/scripts/sync-tokens.mjs
@@ -24,13 +24,29 @@ const SOURCE = join(REPO, 'src/styles/_tokens.scss');
 /** Consumer repo -> path the tokens file should land at, relative to the repo. */
 const CONSUMERS = {
   'xomify-frontend': 'src/styles/_tokens.scss',
-  'xomper-front-end': 'src/styles/_tokens.scss',
-  'xomcloud-frontend': 'src/app/styles/_tokens.scss',
   'xomtracks-frontend': 'src/styles/_tokens.scss',
   'xomforms-frontend': 'src/styles/_tokens.scss',
   'xomcron-frontend': 'src/styles/_tokens.scss',
-  'vest-site': 'src/styles/_tokens.scss',
 };
+
+// NOT consumers, deliberately:
+//
+// vest-site      — placeholder repo; `main` holds only a README, there is no
+//                  Angular app and no stylesheets to migrate.
+//
+// xomcloud-frontend and xomper-front-end are BLOCKED, not skipped. Both already
+// define variables that collide with these token names at DIFFERENT values, so
+// importing this file would silently reassign them across the whole app:
+//
+//   xomcloud  radius-sm 8px->4px, radius-md 12px->8px, radius-lg 16px->12px,
+//             radius-pill 25px->100px  (every rounded corner in the app)
+//   xomper    text-xs 0.75->0.8125rem, text-lg 1.125->1.25rem,
+//             text-xl 1.25->1.5rem, text-2xl 1.5->1.625rem,
+//             text-4xl 2.5->2.375rem  (text resizes app-wide)
+//
+// Neither repo has a visual regression suite, so there is nothing to catch the
+// damage. These need a deliberate decision — adopt the shared values and accept
+// the resize, or keep their own scales — not a mechanical migration.
 
 const write = process.argv.includes('--write');
 const source = readFileSync(SOURCE, 'utf8');

--- a/scripts/sync-tokens.mjs
+++ b/scripts/sync-tokens.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Push the canonical design tokens out to the other Xomware frontends.
+ *
+ * Deliberately a sync script and not an npm package. Publishing would add a
+ * version bump to every consumer for values that are still settling, and there
+ * are only eight repos, all siblings on disk. Once the values stop moving this
+ * becomes @xomware/design-tokens and this script goes away.
+ *
+ * Usage:
+ *   node scripts/sync-tokens.mjs            # report drift, change nothing
+ *   node scripts/sync-tokens.mjs --write    # copy tokens into every consumer
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, '..');
+const CODE = resolve(REPO, '..');
+const SOURCE = join(REPO, 'src/styles/_tokens.scss');
+
+/** Consumer repo -> path the tokens file should land at, relative to the repo. */
+const CONSUMERS = {
+  'xomify-frontend': 'src/styles/_tokens.scss',
+  'xomper-front-end': 'src/styles/_tokens.scss',
+  'xomcloud-frontend': 'src/app/styles/_tokens.scss',
+  'xomtracks-frontend': 'src/styles/_tokens.scss',
+  'xomforms-frontend': 'src/styles/_tokens.scss',
+  'xomcron-frontend': 'src/styles/_tokens.scss',
+  'vest-site': 'src/styles/_tokens.scss',
+};
+
+const write = process.argv.includes('--write');
+const source = readFileSync(SOURCE, 'utf8');
+const hash = createHash('sha256').update(source).digest('hex').slice(0, 12);
+
+// The hash line lets a consumer's CI detect a hand-edit without needing network
+// access or knowledge of this repo.
+const stamped = source.replace(
+  '// Sync with:        node scripts/sync-tokens.mjs   (from xomware-frontend)',
+  `// Sync with:        node scripts/sync-tokens.mjs   (from xomware-frontend)\n// Source hash:      ${hash}`,
+);
+
+let drifted = 0;
+let missing = 0;
+
+for (const [repo, rel] of Object.entries(CONSUMERS)) {
+  const repoDir = join(CODE, repo);
+  if (!existsSync(repoDir)) {
+    console.log(`  SKIP    ${repo} — not checked out`);
+    continue;
+  }
+
+  const dest = join(repoDir, rel);
+  const current = existsSync(dest) ? readFileSync(dest, 'utf8') : null;
+
+  if (current === stamped) {
+    console.log(`  ok      ${repo}`);
+    continue;
+  }
+
+  if (current === null) {
+    missing += 1;
+    console.log(`  MISSING ${repo}  ${write ? '-> writing' : '(run with --write)'}`);
+  } else {
+    drifted += 1;
+    console.log(`  DRIFT   ${repo}  ${write ? '-> overwriting' : '(run with --write)'}`);
+  }
+
+  if (write) {
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, stamped);
+  }
+}
+
+console.log(`\nsource hash ${hash}  •  ${drifted} drifted, ${missing} missing`);
+
+if (!write && (drifted || missing)) {
+  console.log('Nothing was changed. Re-run with --write to apply.');
+  process.exit(1);
+}

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -1,0 +1,89 @@
+// ================================================
+// XOMWARE SHARED DESIGN TOKENS
+// ================================================
+//
+// GENERATED — DO NOT EDIT IN CONSUMER REPOS.
+// Canonical source: xomware-frontend/src/styles/_tokens.scss
+// Sync with:        node scripts/sync-tokens.mjs   (from xomware-frontend)
+//
+// Structure only — type, spacing, radius, motion. NO COLOUR.
+// Each app keeps its own brand palette in its own _variables.scss; that is a
+// per-product decision and does not belong in a shared file.
+//
+// These values were derived by auditing xomware.com against a reference site
+// and are proven there: they took that codebase from ~30 ad-hoc font sizes and
+// 12+ letter-spacings down to a fixed ramp, with stylelint enforcing it.
+
+// ── Type Scale ───────────────────────────────────
+// Declared in rem so browser font-size preferences are respected; px
+// equivalents at a 16px root are in the comments.
+//
+// RULE: no font-size outside this scale. Enforce with stylelint
+// (declaration-property-value-allowed-list — see .stylelintrc.json).
+//
+// $text-3xs (11px) is an escape hatch for dense admin/dashboard chrome, not a
+// design choice. Public surfaces must not go below $text-2xs (12px).
+$text-3xs:  0.6875rem; // 11px — dense admin chrome ONLY
+$text-2xs:  0.75rem;   // 12px — smallest permitted on public surfaces
+$text-xs:   0.8125rem; // 13px
+$text-sm:   0.875rem;  // 14px
+$text-base: 1rem;      // 16px — body default
+$text-md:   1.125rem;  // 18px
+$text-lg:   1.25rem;   // 20px
+$text-xl:   1.5rem;    // 24px
+$text-2xl:  1.625rem;  // 26px
+$text-3xl:  2rem;      // 32px
+$text-4xl:  2.375rem;  // 38px
+$text-5xl:  3rem;      // 48px
+
+// ── Letter Spacing ───────────────────────────────
+// Four values. Never use px tracking — it does not scale with font size, so it
+// breaks at every size other than the one it was tuned for.
+//
+// WATCH OUT: 0.04em sits exactly between $tracking-normal and $tracking-wide.
+// Automatic nearest-match rounds it to 0 and silently strips tracking from
+// uppercase labels. This bit three separate components during the xomware
+// migration. Uppercase micro-labels want $tracking-wide.
+$tracking-tight:  -0.02em; // headings / large display type
+$tracking-normal: 0;
+$tracking-wide:   0.08em;  // uppercase labels, status pills, tags
+$tracking-wider:  0.15em;  // section eyebrows — smallest uppercase type
+
+// ── Font Weights ─────────────────────────────────
+// Only declare weights the app actually loads. Requesting a weight with no
+// matching face makes the browser synthesise faux-bold, which looks smeared.
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
+$font-weight-extrabold: 800;
+
+// ── Spacing (8px base grid) ──────────────────────
+$spacing-xs: 4px;
+$spacing-sm: 8px;
+$spacing-md: 16px;
+$spacing-lg: 24px;
+$spacing-xl: 32px;
+$spacing-2xl: 48px;
+$spacing-3xl: 64px;
+$spacing-4xl: 96px;
+
+// ── Border Radius ────────────────────────────────
+$radius-sm: 4px;
+$radius-md: 8px;
+$radius-lg: 12px;
+$radius-xl: 20px;
+$radius-2xl: 24px;
+$radius-pill: 100px;
+
+// ── Transitions ──────────────────────────────────
+$transition-fast: 150ms ease;
+$transition-base: 300ms ease;
+$transition-slow: 500ms ease;
+$transition-spring: 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+
+// ── Breakpoints ──────────────────────────────────
+$breakpoint-sm: 576px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 992px;
+$breakpoint-xl: 1200px;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,6 +1,11 @@
 // ================================================
-// XOMWARE Design System v2.0 — Midnight Cyan Redesign
+// XOMWARE Design System — app palette + app-specific values
 // ================================================
+//
+// Structural tokens (type scale, tracking, weights, spacing, radius, motion,
+// breakpoints) live in _tokens.scss, which is shared across all Xomware
+// frontends. Everything below is specific to xomware.com.
+@import 'tokens';
 
 // ── Primary Colors ──────────────────────────────
 $brand-cyan: #00b4d8;
@@ -37,101 +42,24 @@ $cyan-accent: linear-gradient(90deg, $brand-cyan 0%, $brand-cyan-light 100%);
 $hero-gradient: radial-gradient(ellipse at 50% 0%, rgba(0, 180, 216, 0.15) 0%, transparent 60%);
 $hero-gradient-alt: radial-gradient(ellipse at 80% 20%, rgba(156, 10, 191, 0.08) 0%, transparent 50%);
 
-// ── Typography ───────────────────────────────────
+// ── Typography (app-specific font stacks) ────────
 $font-stack: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
 $font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
-$font-weight-regular: 400;
-$font-weight-medium: 500;
-$font-weight-semibold: 600;
-$font-weight-bold: 700;
-$font-weight-extrabold: 800;
 // NOTE: index.html loads Inter at wght@400;500;600;700;800.
 // There is no 900 — requesting it produces synthetic faux-bold.
-// Do not add $font-weight-black without adding 900 to the font request.
+// $font-weight-* live in _tokens.scss; do not add a 900 without also adding
+// 900 to the font request in index.html.
 
-// ── Type Scale ───────────────────────────────────
-// Fixed ramp. Before this existed, every size was hand-typed at the call
-// site, which is how the codebase reached ~30 distinct sizes mixing px
-// and rem (14px and 0.875rem were both in use for the same size).
-//
-// Declared in rem so browser font-size preferences are respected; px
-// equivalents at a 16px root are in the comments.
-//
-// RULE: no font-size outside this scale. Enforced by stylelint
-// (declaration-property-value-allowed-list in .stylelintrc.json).
-$text-3xs:  0.6875rem; // 11px — dense admin chrome ONLY, see note below
-$text-2xs:  0.75rem;   // 12px — smallest permitted on public surfaces
-$text-xs:   0.8125rem; // 13px
-$text-sm:   0.875rem;  // 14px
-$text-base: 1rem;      // 16px — body default
-$text-md:   1.125rem;  // 18px
-$text-lg:   1.25rem;   // 20px
-$text-xl:   1.5rem;    // 24px
-$text-2xl:  1.625rem;  // 26px
-$text-3xl:  2rem;      // 32px
-$text-4xl:  2.375rem;  // 38px
-$text-5xl:  3rem;      // 48px
-
-// $text-3xs (11px) is an escape hatch, not a design choice. The codebase
-// has 9px/10px/0.65rem text in the infra dashboard and status badges;
-// forcing those straight to 12px is a +33% jump that reflows those
-// layouts. 11px lets those surfaces migrate without a visual break.
-// Public surfaces (landing, apps, auth, privacy) must not use it.
-
-// ── Letter Spacing ───────────────────────────────
-// Was 12+ ad-hoc values including a stray 0.5px, which breaks at every
-// font size because it does not scale with type. These three cover every
-// real use; $tracking-wide is for uppercase labels and eyebrows, which
-// genuinely need the extra room.
-$tracking-tight:  -0.02em; // headings / large display type
-$tracking-normal: 0;
-$tracking-wide:   0.08em;  // uppercase labels, status pills, tags
-$tracking-wider:  0.15em;  // section eyebrows only — the smallest uppercase
-                           // type, which needs the extra room to stay legible.
-                           // Four values, down from 12+.
-
-// ── Spacing (8px base grid) ──────────────────────
-$spacing-xs: 4px;
-$spacing-sm: 8px;
-$spacing-md: 16px;
-$spacing-lg: 24px;
-$spacing-xl: 32px;
-$spacing-2xl: 48px;
-$spacing-3xl: 64px;
-$spacing-4xl: 96px;
-
-// ── Border Radius ────────────────────────────────
-$radius-sm: 4px;
-$radius-md: 8px;
-$radius-lg: 12px;
-$radius-xl: 20px;
-$radius-2xl: 24px;
-$radius-pill: 100px;
-
-// ── Shadows ──────────────────────────────────────
+// ── Shadows (app-specific) ───────────────────────
 $shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
 $shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
 $shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5);
-$shadow-glow-cyan: 0 0 40px rgba(0, 180, 216, 0.2);
-$shadow-glow-purple: 0 0 40px rgba(156, 10, 191, 0.15);
 
-// ── Glass Morphism ───────────────────────────────
+// ── Glass Morphism (app-specific) ────────────────
 $glass-bg: rgba(20, 20, 40, 0.6);
 $glass-border: rgba(255, 255, 255, 0.08);
 $glass-blur: blur(20px);
 $glass-border-hover: rgba(255, 255, 255, 0.15);
-
-// ── Transitions ──────────────────────────────────
-$transition-fast: 150ms ease;
-$transition-base: 300ms ease;
-$transition-slow: 500ms ease;
-$transition-spring: 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
-
-// ── Breakpoints ──────────────────────────────────
-$breakpoint-sm: 576px;
-$breakpoint-md: 768px;
-$breakpoint-lg: 992px;
-$breakpoint-xl: 1200px;
 
 // ── Glass Morphism Mixin ─────────────────────────
 @mixin glass-card($bg: $glass-bg, $border: $glass-border) {


### PR DESCRIPTION
Answers "did we update everything?" — no, and this closes most of the gap. The research flagged *"only 3 of 9 frontends have a tokens file, at 3 different paths, with 3 different contents"* as the highest-leverage finding, and it had been untouched until now.

## This repo

`_variables.scss` split: structural tokens (type scale, tracking, weights, spacing, radius, motion, breakpoints) move to `_tokens.scss`; colour, shadows, glass values and font stacks stay app-specific. **Colour is a per-product decision and doesn't belong in a shared file.**

Verified behaviour-preserving — all 23 visual baselines unchanged.

`scripts/sync-tokens.mjs` pushes the canonical file to consumers and stamps a source hash into each copy, so a consumer's CI can detect a hand-edit without network access. Dry-run by default.

Deliberately a sync script, not an npm package: publishing would add a version bump to every consumer for values still settling, and there are only a handful of repos, all siblings on disk. It becomes `@xomware/design-tokens` once the values stop moving.

## Adopted (all merged)

| App | Result | Tie fixes |
|---|---|---|
| xomcron-frontend | 95 substitutions | 2 |
| xomtracks-frontend | 237 substitutions | 0 |
| xomforms-frontend | 391 substitutions | 3 |
| xomify-frontend | 81 files, was 64 distinct sizes | 23 |

All four now enforce the scale via stylelint in PR-time CI.

## Two repos BLOCKED — deliberately not migrated

`xomcloud-frontend` and `xomper-front-end` already define variables that collide with the shared token names **at different values**. Importing would silently reassign them app-wide:

- **xomcloud** — `radius-sm` 8→4px, `radius-md` 12→8px, `radius-lg` 16→12px, `radius-pill` 25→100px. Every rounded corner in the app.
- **xomper** — `text-xs` 0.75→0.8125rem, `text-lg` 1.125→1.25rem, `text-xl` 1.25→1.5rem, `text-2xl` 1.5→1.625rem, `text-4xl` 2.5→2.375rem. Text resizes app-wide.

Neither has a visual regression suite, so nothing would catch the damage. Both already have internally coherent scales — the only gain from unifying is cross-app consistency, and the cost is resizing a live app blind. **That's your call, not a mechanical migration.** Documented in the sync script so it can't be forgotten.

`vest-site` isn't a consumer — its `main` holds only a README.

## The tie trap, totalled

`0.04em` sits *exactly* between `$tracking-normal` and `$tracking-wide`, so nearest-match is a coin flip that silently strips tracking from uppercase labels. It hit **31 components across four repos**. Now documented in `_tokens.scss` itself so the next migration doesn't repeat it.

## Also found, not fixed

`xomforms-frontend` declares `'Inter'` but never loads it — no `@font-face`, no webfont link. It's silently rendering in the system fallback everywhere. Out of scope here; worth its own fix.