### PR TITLE
Tighten the radius scale

### DIFF
--- a/scripts/sync-tokens.mjs
+++ b/scripts/sync-tokens.mjs
@@ -27,26 +27,19 @@ const CONSUMERS = {
   'xomtracks-frontend': 'src/styles/_tokens.scss',
   'xomforms-frontend': 'src/styles/_tokens.scss',
   'xomcron-frontend': 'src/styles/_tokens.scss',
+  'xomper-front-end': 'src/styles/_tokens.scss',
+  'xomcloud-frontend': 'src/app/styles/_tokens.scss',
 };
 
-// NOT consumers, deliberately:
+// NOT a consumer:
 //
-// vest-site      — placeholder repo; `main` holds only a README, there is no
-//                  Angular app and no stylesheets to migrate.
+// vest-site — placeholder repo; `main` holds only a README, there is no
+//             Angular app and no stylesheets to migrate.
 //
-// xomcloud-frontend and xomper-front-end are BLOCKED, not skipped. Both already
-// define variables that collide with these token names at DIFFERENT values, so
-// importing this file would silently reassign them across the whole app:
-//
-//   xomcloud  radius-sm 8px->4px, radius-md 12px->8px, radius-lg 16px->12px,
-//             radius-pill 25px->100px  (every rounded corner in the app)
-//   xomper    text-xs 0.75->0.8125rem, text-lg 1.125->1.25rem,
-//             text-xl 1.25->1.5rem, text-2xl 1.5->1.625rem,
-//             text-4xl 2.5->2.375rem  (text resizes app-wide)
-//
-// Neither repo has a visual regression suite, so there is nothing to catch the
-// damage. These need a deliberate decision — adopt the shared values and accept
-// the resize, or keep their own scales — not a mechanical migration.
+// xomcloud-frontend and xomper-front-end were previously blocked: both defined
+// variables colliding with these token names at different values, and neither
+// had a visual regression suite to catch the resulting resize. Both now have
+// suites and have adopted the shared values, so they are ordinary consumers.
 
 const write = process.argv.includes('--write');
 const source = readFileSync(SOURCE, 'utf8');

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -69,11 +69,16 @@ $spacing-3xl: 64px;
 $spacing-4xl: 96px;
 
 // ── Border Radius ────────────────────────────────
-$radius-sm: 4px;
-$radius-md: 8px;
-$radius-lg: 12px;
-$radius-xl: 20px;
-$radius-2xl: 24px;
+// Tightened from 4/8/12/20/24. The reference comparison that started this work
+// uses near-zero corners; going all the way to 0 would fight the rest of this
+// design (glass cards, soft ambient blobs, a cartoon mascot), so this is a
+// step toward crisper rather than a wholesale identity change.
+// Pills are unchanged — they are a shape, not a corner treatment.
+$radius-sm: 3px;
+$radius-md: 6px;
+$radius-lg: 8px;
+$radius-xl: 12px;
+$radius-2xl: 16px;
 $radius-pill: 100px;
 
 // ── Transitions ──────────────────────────────────


### PR DESCRIPTION
The last of the three identity items from the reference comparison.

Radius `sm`/`md`/`lg`/`xl`/`2xl` tightened from **4/8/12/20/24** to **3/6/8/12/16**. Pills unchanged — those are a shape, not a corner treatment.

The reference site uses near-zero corners. Going to 0 would fight the rest of this design — glass cards, soft ambient blobs, a cartoon mascot — so this is a step toward crisper rather than a wholesale identity change.

## Honest finding: the impact is small

Across the three repos that have visual suites, this moved **1–221 pixels per full page**, all of it corner arcs. Corners are tiny areas by definition, and on dark low-contrast cards the difference barely registers.

The reference site's sharp corners read strongly because its surfaces are high-contrast. These aren't. **Corner radius is not the lever it appears to be in this design** — worth knowing before spending more on it.

## Also fixes a real gap in the sync map

`xomper-front-end` and `xomcloud-frontend` were removed from `CONSUMERS` while they were blocked on the collision problem. Both have since adopted the shared tokens behind visual suites — so they were **silently missing token updates**. Restored, and the stale "blocked" note replaced.

I caught this only because this radius change didn't reach them.

## Verification

- xomware — 23 baselines, unchanged (below threshold)
- xomcloud — 12 baselines, unchanged
- xomper — 8 baselines moved, 221px, confined to the search pill and button corners; reviewed and updated

The four repos without suites (xomify, xomtracks, xomforms, xomcron) get companion PRs. Their blast radius is bounded to corner rounding — no layout or type moves.