### PR TITLE
Stop the flight vanishing for the rest of the session after one skip

### DIFF
--- a/src/app/components/space-journey/space-journey.component.ts
+++ b/src/app/components/space-journey/space-journey.component.ts
@@ -37,8 +37,6 @@ const TRAVEL_END = 0.94;
 const VH_PER_PLANET = 0.85;
 const EXTRA_BEATS = 3;
 
-const SKIP_KEY = 'xomware:journey-skipped';
-
 /**
  * How assembled the X constellation is at a given scroll progress, 0..1.
  *
@@ -67,25 +65,22 @@ export function constellationStrength(progress: number): number {
 /**
  * Whether the cinematic intro should mount at all.
  *
- * Three ways out, because a landing page has to stay usable:
- *  - `prefers-reduced-motion` — a pinned, scrubbed flight is exactly the
- *    kind of motion that setting exists to refuse.
- *  - an earlier skip this session — nobody wants the intro twice.
- *  - no `matchMedia` (SSR/prerender) — render the plain page.
+ * Only `prefers-reduced-motion` turns it off — a pinned, scrubbed flight is
+ * exactly the kind of motion that setting exists to refuse. (And no
+ * `matchMedia` at all means SSR/prerender, so render the plain page.)
  *
- * Nothing is lost when it returns false: every app on the rail is also in
+ * This used to also remember a skip in sessionStorage, on the theory that
+ * nobody wants the intro twice. In practice one tap of "Skip intro" made the
+ * whole flight vanish for the rest of the browser session with no way back —
+ * the page just started at the profile, and it read as the feature being
+ * broken. Skipping now only skips the once.
+ *
+ * Nothing is lost when this returns false: every app on the rail is also in
  * the directory grid further down the page.
  */
 export function shouldPlayJourney(): boolean {
   if (typeof window === 'undefined' || !window.matchMedia) return false;
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
-
-  try {
-    return sessionStorage.getItem(SKIP_KEY) !== '1';
-  } catch {
-    // Private browsing or blocked storage — play it rather than fail closed.
-    return true;
-  }
+  return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 @Component({
@@ -176,13 +171,8 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  /** Same exit, but don't make them sit through it again this session. */
+  /** Jump past the flight to the page below. Not remembered — see above. */
   skip(): void {
-    try {
-      sessionStorage.setItem(SKIP_KEY, '1');
-    } catch {
-      // Storage blocked — skipping still works, it just won't be remembered.
-    }
     this.scrollPastPin('smooth');
   }
 


### PR DESCRIPTION
## The bug

`shouldPlayJourney()` remembered a skip in `sessionStorage`, on the theory that nobody wants the intro twice.

In practice, one tap of **Skip intro** made the whole flight disappear for the rest of the browser session, with no way to get it back. The landing dropped from ~12,900px to ~3,600px and opened straight on the profile — which reads as the feature being broken, not as a preference being honoured.

Confirmed against production:

| session | journey mounts | page height |
|---|---|---|
| fresh | yes | 12,957px |
| after one skip | **no** | 3,642px |
| `prefers-reduced-motion` | no | 3,642px |

## The fix

Skipping now only skips the once. `prefers-reduced-motion` still opts out.

## Verified

Skip scrolls past (8,414px) and stores nothing; the flight is back on reload; reduced motion still renders the plain page. Unit tests, visual baselines and `build:prod` all pass — baselines unchanged, since the suite never set the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)