### PR TITLE
Give the planets character, add an outro, section stepping and a rocket

### DIFF
--- a/src/app/components/space-journey/space-journey.component.html
+++ b/src/app/components/space-journey/space-journey.component.html
@@ -71,7 +71,17 @@
       (focus)="onPlanetFocus(i)"
     >
       <span class="planet__body">
-        <span class="planet__disc">
+        <!-- Behind the disc, so the ring passes in front of the body on the
+             near side and behind it on the far side. -->
+        <span
+          class="planet__ring"
+          *ngIf="p.ring"
+          [style.--ring-tilt]="p.ringTilt + 'deg'"
+          aria-hidden="true"
+        ></span>
+
+        <span class="planet__disc" [class]="'is-' + p.surface">
+          <span class="planet__surface" aria-hidden="true"></span>
           <img
             class="planet__mark"
             [class.is-pulsing]="p.logoPulse"
@@ -80,6 +90,30 @@
             loading="lazy"
             decoding="async"
           />
+        </span>
+
+        <!-- One of the locals. Two planets have one; it is a detail to find,
+             not a feature to announce, so it carries no accessible text. -->
+        <span class="planet__alien" *ngIf="p.alien" aria-hidden="true">
+          <svg viewBox="0 0 40 46" xmlns="http://www.w3.org/2000/svg">
+            <g fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round">
+              <path d="M14 12.5C14 7 11.5 3.5 11 1.5" />
+              <path d="M26 12.5C26 7 28.5 3.5 29 1.5" />
+              <path class="planet__alien-arm" d="M28.5 30 L36 22" />
+              <path d="M11.5 30 L5.5 36" />
+              <path d="M16.5 43.5 L16.5 38" />
+              <path d="M23.5 43.5 L23.5 38" />
+            </g>
+            <circle cx="11" cy="1.6" r="1.9" fill="currentColor" />
+            <circle cx="29" cy="1.6" r="1.9" fill="currentColor" />
+            <!-- Head and body as one silhouette so it holds up small. -->
+            <path
+              d="M20 8c-7 0-11.5 5-11.5 11 0 3.4 1.6 6 3.6 7.6-1.4 1.6-2.1 3.7-2.1 6 0 4.3 2.2 6.9 10 6.9s10-2.6 10-6.9c0-2.3-.7-4.4-2.1-6 2-1.6 3.6-4.2 3.6-7.6 0-6-4.5-11-11.5-11z"
+              fill="currentColor"
+            />
+            <ellipse cx="15.6" cy="17.8" rx="2.5" ry="3.4" fill="#05050c" />
+            <ellipse cx="24.4" cy="17.8" rx="2.5" ry="3.4" fill="#05050c" />
+          </svg>
         </span>
       </span>
 
@@ -104,6 +138,21 @@
         </span>
       </span>
     </a>
+
+    <!-- The last thing on the rail. Not a full-screen panel with a button —
+         that version could not work, because it only appeared at the exact
+         scroll position it wanted to send you to. This just arrives like
+         everything else and points at the page below. -->
+    <div class="outro" #outro>
+      <p class="outro__eyebrow">// End of the line</p>
+      <p class="outro__title">That's the suite.</p>
+      <p class="outro__copy">Keep scrolling for the rest of the site.</p>
+      <span class="outro__cue" aria-hidden="true">
+        <svg viewBox="0 0 24 24">
+          <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" fill="currentColor" />
+        </svg>
+      </span>
+    </div>
   </div>
 
   <!-- Mobile-only readout for the centred planet.
@@ -115,6 +164,22 @@
   <div class="journey__focus" #focus aria-hidden="true">
     <span class="focus__name"></span>
     <span class="focus__description"></span>
+  </div>
+
+  <!-- Step between planets in either direction. Fades in with the flight —
+       there is nothing to step through during the intro or the brief. -->
+  <div class="journey__steps" #steps>
+    <button type="button" class="journey__step" (click)="jump(-1)" aria-label="Previous app">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M14 6l1.41 1.41L10.83 12l4.58 4.59L14 18l-6-6z" fill="currentColor" />
+      </svg>
+    </button>
+    <span class="journey__step-count" #stepCount></span>
+    <button type="button" class="journey__step" (click)="jump(1)" aria-label="Next app">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor" />
+      </svg>
+    </button>
   </div>
 
   <!-- Always reachable: the journey must never be the only way down. -->

--- a/src/app/components/space-journey/space-journey.component.scss
+++ b/src/app/components/space-journey/space-journey.component.scss
@@ -322,6 +322,10 @@
 
 .planet__disc {
   position: relative;
+  // Above the ring, so the ring only shows where it extends past the body —
+  // which is what makes it read as a ring seen near edge-on rather than a
+  // halo drawn around the outside.
+  z-index: 1;
   display: grid;
   place-items: center;
   width: calc(clamp(8rem, 22vw, 15rem) * var(--planet-size));
@@ -344,6 +348,10 @@
 }
 
 .planet__mark {
+  // Lifted above .planet__surface: that is absolutely positioned, so without
+  // a stacking order of its own it would paint straight over the logo.
+  position: relative;
+  z-index: 1;
   // A wide box, not a square: these are banner lockups, so constraining them
   // to a square slot would shrink them to a sliver to fit the height.
   // object-fit keeps the aspect ratio inside it.
@@ -447,6 +455,161 @@
   }
 }
 
+// ── Surface character ────────────────────────────
+// Each body wears one of four treatments plus an optional ring, assigned by
+// position in planets.ts rather than at random so the composition is the same
+// every run. All of it is drawn under .planet__mark, which stays untouched —
+// the product logos are the one thing here that must not be stylised.
+.planet__surface {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  overflow: hidden;
+  opacity: 0.85;
+  // Lit from the upper left, same as the disc beneath and the asteroids in
+  // the field, so the whole scene agrees about where the light is.
+  mask-image: radial-gradient(circle at 34% 28%, #000 0%, #000 62%, transparent 88%);
+}
+
+.planet__disc.is-cratered .planet__surface {
+  background:
+    radial-gradient(circle at 30% 62%, rgba(0, 0, 0, 0.42) 0 8%, transparent 9%),
+    radial-gradient(circle at 62% 34%, rgba(0, 0, 0, 0.34) 0 5.5%, transparent 6.5%),
+    radial-gradient(circle at 72% 68%, rgba(0, 0, 0, 0.38) 0 6.5%, transparent 7.5%),
+    radial-gradient(circle at 44% 22%, rgba(0, 0, 0, 0.28) 0 3.5%, transparent 4.5%),
+    radial-gradient(circle at 24% 40%, rgba(255, 255, 255, 0.05) 0 4%, transparent 5%);
+}
+
+.planet__disc.is-banded .planet__surface {
+  background: repeating-linear-gradient(
+    172deg,
+    rgba(var(--app-rgb), 0.16) 0 6%,
+    transparent 6% 12%,
+    rgba(0, 0, 0, 0.2) 12% 17%,
+    transparent 17% 24%
+  );
+}
+
+.planet__disc.is-swirled .planet__surface {
+  background:
+    radial-gradient(ellipse 60% 26% at 38% 40%, rgba(var(--app-rgb), 0.26) 0%, transparent 70%),
+    radial-gradient(ellipse 44% 18% at 66% 62%, rgba(255, 255, 255, 0.07) 0%, transparent 72%),
+    radial-gradient(ellipse 30% 14% at 30% 72%, rgba(0, 0, 0, 0.3) 0%, transparent 70%);
+}
+
+.planet__disc.is-icy .planet__surface {
+  background:
+    linear-gradient(168deg, rgba(214, 240, 255, 0.16) 0%, transparent 34%),
+    linear-gradient(348deg, rgba(214, 240, 255, 0.13) 0%, transparent 30%),
+    radial-gradient(ellipse 50% 22% at 56% 48%, rgba(0, 0, 0, 0.22) 0%, transparent 70%);
+}
+
+// ── Rings ────────────────────────────────────────
+.planet__ring {
+  position: absolute;
+  z-index: 0;
+  top: 50%;
+  left: 50%;
+  width: calc(clamp(8rem, 22vw, 15rem) * var(--planet-size) * 1.72);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  // Flattened into an ellipse and tilted, which is what sells it as a ring
+  // seen edge-on rather than a halo drawn around the body.
+  transform: translate(-50%, -50%) rotate(var(--ring-tilt)) scaleY(0.24);
+  border: 3px solid rgba(var(--app-rgb), 0.42);
+  box-shadow:
+    0 0 0 5px rgba(var(--app-rgb), 0.1),
+    inset 0 0 0 4px rgba(255, 255, 255, 0.05);
+  pointer-events: none;
+}
+
+// ── The locals ───────────────────────────────────
+.planet__alien {
+  position: absolute;
+  z-index: 2;
+  // Standing on the upper-right shoulder of the body.
+  top: 4%;
+  left: 74%;
+  width: calc(clamp(8rem, 22vw, 15rem) * var(--planet-size) * 0.19);
+  color: rgba(var(--app-rgb), 0.9);
+  pointer-events: none;
+
+  svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6));
+  }
+}
+
+// Waves from the elbow rather than the shoulder, so the arm swings instead of
+// the whole body rocking.
+.planet__alien-arm {
+  transform-origin: 28.5px 30px;
+  animation: alien-wave 1.6s ease-in-out infinite;
+}
+
+@keyframes alien-wave {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  50% {
+    transform: rotate(-26deg);
+  }
+}
+
+// ── Outro ────────────────────────────────────────
+.outro {
+  position: relative;
+  flex: 0 0 auto;
+  width: 62vw;
+  max-width: 30rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-sm;
+  text-align: center;
+}
+
+.outro__eyebrow {
+  margin: 0;
+  font-family: $font-mono;
+  font-size: $text-2xs;
+  letter-spacing: $tracking-wider;
+  font-weight: $font-weight-medium;
+  text-transform: uppercase;
+  color: $brand-cyan;
+}
+
+.outro__title {
+  margin: 0;
+  font-family: $font-display;
+  font-size: clamp(1.7rem, 4.5vw, 2.6rem);
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-tight;
+  color: $text-primary;
+}
+
+.outro__copy {
+  margin: 0;
+  font-size: $text-sm;
+  line-height: 1.6;
+  color: $text-secondary;
+}
+
+.outro__cue {
+  margin-top: $spacing-sm;
+  color: $text-muted;
+
+  svg {
+    width: 22px;
+    height: 22px;
+    animation: cue-bob 1.8s ease-in-out infinite;
+  }
+}
+
 // ── Mobile focus readout ─────────────────────────
 // Hidden by default; on narrow viewports it replaces the per-planet labels.
 .journey__focus {
@@ -474,6 +637,69 @@
 @media (prefers-reduced-motion: reduce) {
   .is-pulsing {
     animation: none;
+  }
+}
+
+// ── Step controls ────────────────────────────────
+// Bottom-left, opposite the skip button so the two never collide.
+.journey__steps {
+  position: absolute;
+  z-index: 5;
+  left: $spacing-xl;
+  bottom: $spacing-xl;
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  // The timeline fades this in when the flight starts.
+  opacity: 0;
+}
+
+.journey__step {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid $glass-border;
+  background: rgba(10, 10, 20, 0.6);
+  backdrop-filter: blur(8px);
+  color: $text-secondary;
+  cursor: pointer;
+  transition:
+    color $transition-fast,
+    border-color $transition-fast;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      color: $text-primary;
+      border-color: $glass-border-hover;
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: 2px;
+  }
+}
+
+.journey__step-count {
+  min-width: 3.2rem;
+  text-align: center;
+  font-family: $font-mono;
+  font-size: $text-2xs;
+  letter-spacing: $tracking-wide;
+  color: $text-muted;
+}
+
+@media (max-width: $breakpoint-md) {
+  .journey__steps {
+    left: $spacing-md;
+    bottom: $spacing-md;
   }
 }
 
@@ -595,7 +821,9 @@
 // (see shouldPlayJourney), but if it ever renders, nothing should move.
 @media (prefers-reduced-motion: reduce) {
   .intro__char,
-  .intro__cue-icon {
+  .intro__cue-icon,
+  .planet__alien-arm,
+  .outro__cue svg {
     animation: none;
   }
 

--- a/src/app/components/space-journey/space-journey.component.ts
+++ b/src/app/components/space-journey/space-journey.component.ts
@@ -98,6 +98,9 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
   @ViewChild('intro', { static: true }) intro!: ElementRef<HTMLElement>;
   @ViewChild('brief', { static: true }) brief!: ElementRef<HTMLElement>;
   @ViewChild('focus', { static: true }) focus!: ElementRef<HTMLElement>;
+  @ViewChild('outro', { static: true }) outro!: ElementRef<HTMLElement>;
+  @ViewChild('steps', { static: true }) steps!: ElementRef<HTMLElement>;
+  @ViewChild('stepCount', { static: true }) stepCount!: ElementRef<HTMLElement>;
   @ViewChildren('planetEl') planetEls!: QueryList<ElementRef<HTMLElement>>;
 
   private starfield?: Starfield;
@@ -143,8 +146,8 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
     if (!trigger) return;
 
     const span = trigger.end - trigger.start;
-    // Same measured fractions the highlight uses, so focus lands the planet
-    // in the centre of the screen rather than merely somewhere nearby.
+    // Same measured fractions the highlight and the step controls use, so
+    // focus lands the planet in the centre rather than merely somewhere near.
     const share = this.ensureFractions()[index] ?? 0;
     const target = trigger.start + span * (BRIEF_END + (TRAVEL_END - BRIEF_END) * share);
 
@@ -169,6 +172,35 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
 
       window.scrollTo({ top: target, behavior: 'instant' as ScrollBehavior });
     });
+  }
+
+  /**
+   * Step to the previous/next planet.
+   *
+   * Reuses the same measured fractions as the highlight and keyboard focus, so
+   * "next" always lands the following planet dead centre rather than nudging
+   * the scroll by a guessed amount.
+   */
+  jump(direction: 1 | -1): void {
+    const count = this.planets.length;
+    if (!count) return;
+
+    // activeIndex is -1 until the first scroll frame; treat that as "before
+    // the first planet" so a forward press from the intro goes to planet one.
+    const from = this.activeIndex < 0 ? (direction > 0 ? -1 : 0) : this.activeIndex;
+    const next = Math.min(Math.max(from + direction, 0), count - 1);
+    this.scrollToPlanet(next);
+  }
+
+  /** Scroll so a given planet sits in the centre of the screen. */
+  private scrollToPlanet(index: number): void {
+    const trigger = this.trigger;
+    if (!trigger) return;
+
+    const span = trigger.end - trigger.start;
+    const share = this.ensureFractions()[index] ?? 0;
+    const target = trigger.start + span * (BRIEF_END + (TRAVEL_END - BRIEF_END) * share);
+    window.scrollTo({ top: target, behavior: 'smooth' });
   }
 
   /** Jump past the flight to the page below. Not remembered — see above. */
@@ -273,8 +305,20 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
         },
         BRIEF_END,
       )
-      // The mobile readout belongs to the flight only — see the note on
-      // .journey__focus for why it must not be visible before then.
+      // The step controls and the mobile readout both belong to the flight
+      // only: there is nothing to step through, and nothing centred to report,
+      // until the planets start moving.
+      .fromTo(
+        this.steps.nativeElement,
+        { opacity: 0 },
+        { opacity: 1, ease: 'none', duration: 0.03 },
+        BRIEF_END,
+      )
+      .to(
+        this.steps.nativeElement,
+        { opacity: 0, ease: 'none', duration: 1 - TRAVEL_END },
+        TRAVEL_END,
+      )
       .fromTo(
         this.focus.nativeElement,
         { opacity: 0 },
@@ -286,30 +330,23 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
         { opacity: 0, ease: 'none', duration: 1 - TRAVEL_END },
         TRAVEL_END,
       )
-      // A short drift past the last planet, then the pin releases straight
-      // into the page. There used to be an arrival panel here with a "continue
-      // to full site" button, but it only appeared at the very end of the pin —
-      // which is the scroll position it wanted to send you to, so the button
-      // could never do anything.
-      .to(
-        rail,
-        {
-          x: () => -(this.railTravel(els) + window.innerWidth * 0.4),
-          ease: 'power1.in',
-          duration: 1 - TRAVEL_END,
-        },
-        TRAVEL_END,
-      );
+      ;
+    // Travel ends on the outro at TRAVEL_END and simply holds there for the
+    // last stretch of the pin, so the closing card gets a beat to be read
+    // before the page takes over. Nothing animates in that window on purpose.
 
     this.timeline = timeline;
     this.trigger = timeline.scrollTrigger;
   }
 
   /**
-   * Distance the rail must travel for the final planet to land dead centre.
+   * Distance the rail must travel for its last item to land dead centre.
+   *
+   * That item is the outro, not the last planet — the flight should come to
+   * rest on the closing card rather than sailing past it.
    */
   private railTravel(els: HTMLElement[]): number {
-    const last = els[els.length - 1];
+    const last = this.outro?.nativeElement ?? els[els.length - 1];
     if (!last) return 0;
     const centre = last.offsetLeft + last.offsetWidth / 2;
     return Math.max(0, centre - window.innerWidth / 2);
@@ -387,5 +424,7 @@ export class SpaceJourneyComponent implements AfterViewInit, OnDestroy {
     const description = focus.querySelector('.focus__description');
     if (name) name.textContent = planet.name;
     if (description) description.textContent = planet.description;
+
+    this.stepCount.nativeElement.textContent = `${index + 1} / ${this.planets.length}`;
   }
 }

--- a/src/app/components/space-journey/starfield.ts
+++ b/src/app/components/space-journey/starfield.ts
@@ -45,6 +45,16 @@ interface Meteor {
   maxLife: number;
 }
 
+/** Somebody out there. Crosses the field now and then, and is gone. */
+interface Rocket {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** Counts up; the ship despawns once it has cleared the far edge. */
+  life: number;
+}
+
 /** A tumbling rock. Drawn as an irregular polygon so no two look alike. */
 interface Asteroid {
   x: number;
@@ -79,6 +89,8 @@ const STAR_COLOURS = [
 const COLOUR_WEIGHTS = [0.42, 0.24, 0.16, 0.12, 0.06];
 
 const ASTEROID_COUNT = 7;
+/** Seconds between rocket sightings, before jitter. Rare on purpose. */
+const ROCKET_INTERVAL = 15;
 /** Seconds between shooting stars, before jitter. */
 const METEOR_INTERVAL = 2.4;
 const MAX_METEORS = 3;
@@ -138,7 +150,9 @@ export class Starfield {
 
   private asteroids: Asteroid[] = [];
   private meteors: Meteor[] = [];
+  private rocket: Rocket | null = null;
   private nextMeteorAt = METEOR_INTERVAL;
+  private nextRocketAt = ROCKET_INTERVAL;
   private rand: () => number = mulberry32(1);
 
   private progress = 0;
@@ -355,6 +369,7 @@ export class Starfield {
     this.xStars = [];
     this.asteroids = [];
     this.meteors = [];
+    this.rocket = null;
     this.starSprites = [];
     this.spikeSprites = [];
     this.ctx = null;
@@ -393,6 +408,37 @@ export class Starfield {
       m.life += 1;
       if (m.life > m.maxLife) this.meteors.splice(i, 1);
     }
+
+    if (!this.rocket && this.time >= this.nextRocketAt) {
+      this.spawnRocket();
+      this.nextRocketAt = this.time + ROCKET_INTERVAL + this.rand() * 14;
+    }
+
+    if (this.rocket) {
+      this.rocket.x += this.rocket.vx;
+      this.rocket.y += this.rocket.vy;
+      this.rocket.life += 1;
+      // Gone once it has cleared the far edge with room to spare.
+      const margin = 140;
+      if (this.rocket.x < -margin || this.rocket.x > this.width + margin) this.rocket = null;
+    }
+  }
+
+  private spawnRocket(): void {
+    const rand = this.rand;
+    const leftToRight = rand() > 0.5;
+    // Much slower than a meteor: this one is under power, not falling.
+    const speed = 1.9 + rand() * 1.5;
+    // Only a slight climb or dive, so it reads as a course rather than a dive.
+    const climb = (rand() - 0.5) * 0.5;
+
+    this.rocket = {
+      x: leftToRight ? -120 : this.width + 120,
+      y: this.height * (0.12 + rand() * 0.68),
+      vx: (leftToRight ? 1 : -1) * speed,
+      vy: climb,
+      life: 0,
+    };
   }
 
   private spawnMeteor(): void {
@@ -474,7 +520,65 @@ export class Starfield {
     }
 
     this.drawMeteors(ctx);
+    this.drawRocket(ctx, form);
     ctx.globalAlpha = 1;
+  }
+
+  /** The ship, drawn nose-first along its own heading. */
+  private drawRocket(ctx: CanvasRenderingContext2D, form: number): void {
+    const r = this.rocket;
+    if (!r) return;
+
+    // Recedes with the rest of the sky while the mark assembles.
+    ctx.globalAlpha = 1 - form * 0.7;
+    ctx.save();
+    ctx.translate(r.x, r.y);
+    ctx.rotate(Math.atan2(r.vy, r.vx));
+
+    // Exhaust first, so the hull paints over its root. Length flickers.
+    const flame = 13 + Math.sin(this.time * 22) * 4;
+    const plume = ctx.createLinearGradient(-9, 0, -9 - flame, 0);
+    plume.addColorStop(0, 'rgba(255, 214, 130, 0.95)');
+    plume.addColorStop(0.45, 'rgba(255, 138, 46, 0.6)');
+    plume.addColorStop(1, 'rgba(255, 108, 32, 0)');
+    ctx.fillStyle = plume;
+    ctx.beginPath();
+    ctx.moveTo(-9, -3.4);
+    ctx.lineTo(-9 - flame, 0);
+    ctx.lineTo(-9, 3.4);
+    ctx.closePath();
+    ctx.fill();
+
+    // Fins.
+    ctx.fillStyle = 'rgba(196, 84, 74, 0.95)';
+    ctx.beginPath();
+    ctx.moveTo(-7, -3);
+    ctx.lineTo(-13, -8.5);
+    ctx.lineTo(-5, -3);
+    ctx.closePath();
+    ctx.moveTo(-7, 3);
+    ctx.lineTo(-13, 8.5);
+    ctx.lineTo(-5, 3);
+    ctx.closePath();
+    ctx.fill();
+
+    // Hull: a nose cone tapering back to the engine.
+    ctx.fillStyle = 'rgba(226, 232, 246, 0.96)';
+    ctx.beginPath();
+    ctx.moveTo(17, 0);
+    ctx.quadraticCurveTo(6, -5.4, -9, -4.2);
+    ctx.lineTo(-9, 4.2);
+    ctx.quadraticCurveTo(6, 5.4, 17, 0);
+    ctx.closePath();
+    ctx.fill();
+
+    // Porthole.
+    ctx.fillStyle = 'rgba(0, 180, 216, 0.95)';
+    ctx.beginPath();
+    ctx.arc(4.5, 0, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.restore();
   }
 
   /** Tumbling rocks drifting through the field. */

--- a/src/app/data/planets.ts
+++ b/src/app/data/planets.ts
@@ -22,10 +22,18 @@ export interface Planet {
   status: 'live' | 'coming-soon';
   /** Human labels for every platform the product ships on, e.g. ['Web', 'iOS']. */
   platforms: string[];
-  /** Layout only — see LAYOUT below. */
+  /** Layout and surface treatment only — see LAYOUT below. */
   size: number;
   offsetY: number;
   depth: number;
+  /** Surface treatment. Purely cosmetic; see LAYOUT. */
+  surface: 'cratered' | 'banded' | 'swirled' | 'icy';
+  /** Whether the body carries a ring. */
+  ring: boolean;
+  /** Degrees of tilt on that ring, so no two sit at the same angle. */
+  ringTilt: number;
+  /** A small inhabitant waving from the rim. Two of them, so it stays a find. */
+  alien: boolean;
 }
 
 /**
@@ -35,20 +43,28 @@ export interface Planet {
  * journey untestable; a fixed table gives the same varied-but-deliberate
  * arrangement every time. Cycled with `%` so adding a 9th app still works.
  *
- * size    — multiplier on the base planet diameter
- * offsetY — vertical drift from the travel line, in vh
- * depth   — parallax rate; >1 passes nearer the camera than the star layers
+ * size     — multiplier on the base planet diameter
+ * offsetY  — vertical drift from the travel line, in vh
+ * depth    — parallax rate; >1 passes nearer the camera than the star layers
+ * surface  — which surface treatment the body wears
+ * ring     — whether it carries a ring
+ * ringTilt — that ring's tilt in degrees
+ * alien    — a small waving inhabitant on the rim
+ *
+ * Rings are spread out rather than given to neighbours, so two ringed bodies
+ * are never on screen together — one at a time reads as a feature, a row of
+ * them reads as a texture.
  */
 const LAYOUT = [
-  { size: 1.0, offsetY: -7, depth: 0.9 },
-  { size: 0.84, offsetY: 11, depth: 0.7 },
-  { size: 1.12, offsetY: -13, depth: 1.05 },
-  { size: 0.92, offsetY: 5, depth: 0.8 },
-  { size: 1.04, offsetY: -4, depth: 0.95 },
-  { size: 0.88, offsetY: 13, depth: 0.72 },
-  { size: 1.16, offsetY: -10, depth: 1.1 },
-  { size: 0.96, offsetY: 6, depth: 0.85 },
-];
+  { size: 1.0, offsetY: -7, depth: 0.9, surface: 'swirled', ring: false, ringTilt: 0, alien: false },
+  { size: 0.84, offsetY: 11, depth: 0.7, surface: 'cratered', ring: false, ringTilt: 0, alien: true },
+  { size: 1.12, offsetY: -13, depth: 1.05, surface: 'banded', ring: true, ringTilt: -16, alien: false },
+  { size: 0.92, offsetY: 5, depth: 0.8, surface: 'icy', ring: false, ringTilt: 0, alien: false },
+  { size: 1.04, offsetY: -4, depth: 0.95, surface: 'cratered', ring: false, ringTilt: 0, alien: false },
+  { size: 0.88, offsetY: 13, depth: 0.72, surface: 'swirled', ring: true, ringTilt: 12, alien: false },
+  { size: 1.16, offsetY: -10, depth: 1.1, surface: 'banded', ring: false, ringTilt: 0, alien: true },
+  { size: 0.96, offsetY: 6, depth: 0.85, surface: 'icy', ring: true, ringTilt: -24, alien: false },
+] as const;
 
 const PLATFORM_LABEL: Record<AppCard['platform'], string> = {
   web: 'Web',


### PR DESCRIPTION
## Planet character

Eight identically-treated discs before. Each now wears one of four surface treatments — **cratered, banded, swirled, icy** — and three carry a **tilted ring**.

All assigned by position in `planets.ts` rather than rolled at random, so the composition is identical every run and stays testable. Rings are spaced apart deliberately: one on screen at a time reads as a feature, a row of them reads as a texture.

## The locals

Two planets have a small inhabitant waving from the rim. Inline SVG; it waves **from the elbow** so the arm swings rather than the whole body rocking, and carries no accessible text — it's a detail to find, not a feature to announce. Stops under `prefers-reduced-motion`.

## Outro

A closing item at the end of the rail that arrives like everything else and points at the page below — rather than the full-screen panel the arrival used to be, which only appeared at the exact scroll position its button wanted to send you to.

Travel now measures to the outro instead of the last planet, so the flight comes to rest on it and **holds** for the last stretch of the pin, giving it a beat to be read.

## Section stepping

Prev/next through the planets, reusing the **same measured centring positions** as the highlight and keyboard focus — so "next" lands the following planet dead centre instead of nudging the scroll by a guess. Fades in with the flight; there's nothing to step through during the intro or the brief.

Verified: 1/8 → next → next → 3/8 (Xomper) → prev → 2/8 (XomCloud); outro lands at offset 0 from centre.

## Rocket

Crosses the field every fifteen-odd seconds — under power rather than falling, with a flickering exhaust drawn along its heading. Frozen in the visual build with the meteors.

## Note for future testing

`build:visual` sets `staticScene`, which freezes the rocket, the meteors *and* the asteroid tumble. Screenshots of any of them must come from `build:prod` — I lost time to this exact trap while verifying the rocket.

## Verification

`lint:css`, `tsc`, unit tests and `build:prod` pass. Visual baselines unchanged and green across two runs — they capture scroll 0, where the planets are off-screen and the new controls are still hidden, so nothing there should have moved.

**Bundle: 1,035,218 of 1,048,576 — headroom is down to ~13KB.** Still the *warning* threshold (hard error is 2MB), but this is the point where lazy-loading `/command` stops being optional housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)