### PR TITLE
Reword the brief — it was reading as a boast

### DIFF
--- a/src/app/components/space-journey/space-journey.component.html
+++ b/src/app/components/space-journey/space-journey.component.html
@@ -28,11 +28,10 @@
        jumped straight to logos, so a visitor never learned what any of it is. -->
   <div class="journey__brief" #brief>
     <p class="brief__eyebrow">// What this is</p>
-    <h2 class="brief__title">Built end to end,<br />by one engineer.</h2>
+    <h2 class="brief__title">A workshop,<br />not a company.</h2>
     <p class="brief__copy">
-      Xomware is where I design, build and ship my own products:
-      {{ planets.length }} of them so far, across web and iOS, running on
-      infrastructure I manage myself.
+      Xomware is where I build my own things — {{ planets.length }} of them so
+      far, across web and iOS, plus the infrastructure underneath.
     </p>
     <ul class="brief__disciplines">
       <li class="brief__discipline">


### PR DESCRIPTION
"Built end to end, by one engineer" was a brag dressed up as a description.

The brief now says what Xomware **is** rather than how impressive it is:

```
// WHAT THIS IS
A workshop, not a company.
Xomware is where I build my own things — 8 of them so far,
across web and iOS, plus the infrastructure underneath.
```

Same information, including the product count still read from the data so it can't drift. "Running on infrastructure I manage myself" went the same way as the headline — it's now just "plus the infrastructure underneath", which states the fact without flexing about it.

The four discipline cards below are unchanged.

## Verification

`lint:css`, `tsc`, unit tests, `build:prod` and the visual suite all pass.

Baselines are unchanged, which is the expected result: the brief sits at `opacity: 0` at scroll 0 and is absolutely positioned, so neither the new text nor its shorter wrap affects the captured page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)