### PR TITLE
Admin: show who is visiting and the path they took

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -149,7 +149,12 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src"
+              ]
+            }
           }
         }
       }

--- a/src/app/components/admin/admin.component.html
+++ b/src/app/components/admin/admin.component.html
@@ -31,6 +31,98 @@
     </section>
 
     <div class="admin-grid">
+      <!-- Visitors. Grouped by visitorId, which survives sign-in, so an
+           anonymous session that converts stays one row. -->
+      <section class="card visitors-card" aria-labelledby="visitors-heading">
+        <div class="card-header">
+          <div>
+            <h2 id="visitors-heading">Visitors</h2>
+            <p class="card-subtitle">
+              <ng-container *ngIf="visitors.length; else visitorsSubtitle">
+                {{ visitors.length }} unique · {{ identifiedCount }} signed in
+              </ng-container>
+              <ng-template #visitorsSubtitle>Who came, and where they went</ng-template>
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            (click)="loadVisitors()"
+            [disabled]="visitorsLoading"
+          >
+            {{ visitorsLoading ? 'Loading…' : 'Refresh' }}
+          </button>
+        </div>
+
+        <div *ngIf="visitorsError" class="error-banner" role="alert">
+          <span>{{ visitorsError }}</span>
+          <button type="button" class="btn-link" (click)="loadVisitors()">Retry</button>
+        </div>
+
+        <div *ngIf="visitorsLoading && visitors.length === 0" class="loading-state">
+          Loading visitors…
+        </div>
+
+        <div
+          *ngIf="!visitorsLoading && visitors.length === 0 && !visitorsError"
+          class="empty-state"
+        >
+          No visitors recorded for {{ dateForm.value.date }}.
+        </div>
+
+        <div *ngIf="visitors.length > 0" class="visitors-list">
+          <div class="visitor-row" *ngFor="let v of visitors">
+            <button
+              type="button"
+              class="visitor-summary"
+              (click)="toggleVisitor(v.visitorId)"
+              [attr.aria-expanded]="expandedVisitor === v.visitorId"
+            >
+              <span class="visitor-who" [class.is-identified]="v.identified">
+                {{ v.identity }}
+                <span class="pill pill-signup" *ngIf="v.converted">converted</span>
+              </span>
+              <span class="visitor-stat">
+                {{ v.pageviews }} {{ v.pageviews === 1 ? 'view' : 'views' }}
+              </span>
+              <span class="visitor-stat">
+                {{ v.outbound.length }}
+                {{ v.outbound.length === 1 ? 'click-through' : 'click-throughs' }}
+              </span>
+              <span class="visitor-stat visitor-errors" *ngIf="v.errors">
+                {{ v.errors }} {{ v.errors === 1 ? 'error' : 'errors' }}
+              </span>
+              <span class="visitor-time">
+                {{ formatTime(v.lastSeen) }} · {{ formatSpan(v) }}
+              </span>
+            </button>
+
+            <div class="visitor-detail" *ngIf="expandedVisitor === v.visitorId">
+              <p class="visitor-meta">Journey</p>
+              <ol class="visitor-journey">
+                <li *ngFor="let step of v.journey">{{ step }}</li>
+                <li class="visitor-journey-empty" *ngIf="!v.journey.length">
+                  No pages recorded.
+                </li>
+              </ol>
+              <ng-container *ngIf="v.outbound.length">
+                <p class="visitor-meta">Left for</p>
+                <ul class="visitor-outbound">
+                  <li *ngFor="let o of v.outbound">{{ o.app }}</li>
+                </ul>
+              </ng-container>
+            </div>
+          </div>
+        </div>
+
+        <div class="card-footer" *ngIf="visitorsTruncated">
+          <p class="visitor-meta">
+            Showing the most recent 3,000 events for this day — older activity is
+            not included in these totals.
+          </p>
+        </div>
+      </section>
+
       <!-- Events card -->
       <section class="card events-card" aria-labelledby="events-heading">
         <div class="card-header">

--- a/src/app/components/admin/admin.component.scss
+++ b/src/app/components/admin/admin.component.scss
@@ -365,6 +365,141 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+// --- Visitors ---
+.visitors-card {
+  // Full width: the summary row carries five columns and a journey below it.
+  grid-column: 1 / -1;
+}
+
+.visitors-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.visitor-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.visitor-summary {
+  display: grid;
+  grid-template-columns: 1fr 90px 130px auto 160px;
+  gap: $spacing-sm;
+  align-items: baseline;
+  width: 100%;
+  padding: $spacing-sm 0;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  font-family: $font-stack;
+  font-size: $text-xs;
+  color: $text-primary;
+  cursor: pointer;
+
+  &:hover {
+    color: $brand-cyan-light;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-cyan;
+    outline-offset: -2px;
+  }
+}
+
+.visitor-who {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  // Anonymous visitors are the majority and the least interesting; a known
+  // email is what you actually scan for, so only that one gets full contrast.
+  color: $text-muted;
+
+  &.is-identified {
+    color: $text-primary;
+    font-weight: $font-weight-semibold;
+  }
+}
+
+.visitor-stat {
+  color: $text-muted;
+  font-variant-numeric: tabular-nums;
+}
+
+.visitor-errors {
+  color: #ff5252;
+}
+
+.visitor-time {
+  color: $text-muted;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.visitor-detail {
+  padding: 0 0 $spacing-sm;
+}
+
+.visitor-meta {
+  margin: 0 0 $spacing-xs;
+  font-size: $text-3xs;
+  text-transform: uppercase;
+  letter-spacing: $tracking-wide;
+  color: $text-muted;
+}
+
+.visitor-journey {
+  margin: 0 0 $spacing-sm;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-xs;
+
+  li {
+    padding: 2px $spacing-sm;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: $radius-pill;
+    font-size: $text-3xs;
+    color: $text-muted;
+  }
+
+  // Arrows between steps make the order readable at a glance.
+  li + li::before {
+    content: '→ ';
+    opacity: 0.5;
+  }
+}
+
+.visitor-journey-empty {
+  background: transparent !important;
+  border: 0 !important;
+}
+
+.visitor-outbound {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-xs;
+
+  li {
+    padding: 2px $spacing-sm;
+    background: rgba(245, 165, 36, 0.08);
+    border: 1px solid rgba(245, 165, 36, 0.3);
+    border-radius: $radius-pill;
+    font-size: $text-3xs;
+    color: #f5a524;
+  }
+}
+
 // --- Errors ---
 .errors-card {
   // Spans both columns: stacks read badly at half width once a message and a
@@ -518,6 +653,15 @@
 @media (max-width: $breakpoint-md) {
   .admin-content {
     padding: calc(#{$spacing-sm} + var(--nav-h)) $spacing-sm $spacing-sm;
+  }
+
+  // Drop to identity + recency; the counts are in the expanded detail.
+  .visitor-summary {
+    grid-template-columns: 1fr 110px;
+
+    .visitor-stat {
+      display: none;
+    }
   }
 
   .events-row {

--- a/src/app/components/admin/admin.component.spec.ts
+++ b/src/app/components/admin/admin.component.spec.ts
@@ -1,0 +1,196 @@
+import { TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { AdminComponent } from './admin.component';
+import {
+  AdminEvent,
+  AdminEventType,
+  AdminService,
+  EventsListRequest,
+  EventsListResponse,
+} from '../../services/admin.service';
+
+let seq = 0;
+const ev = (
+  eventType: AdminEventType,
+  time: string,
+  extra: Partial<AdminEvent> = {},
+): AdminEvent => ({
+  eventId: `e${++seq}`,
+  eventType,
+  eventTime: `2026-08-14T${time}:00.000Z`,
+  eventDate: '2026-08-14',
+  userId: extra.email ? 'cognito-sub' : `anon:${extra.visitorId ?? 'v1'}`,
+  ...extra,
+});
+
+describe('AdminComponent — visitors', () => {
+  let component: AdminComponent;
+  let admin: jasmine.SpyObj<AdminService>;
+
+  /** Serve one page of events, then no cursor. */
+  const serve = (items: AdminEvent[]) => {
+    admin.listEvents.and.callFake((req: EventsListRequest = {}) => {
+      const filtered = req.eventType
+        ? items.filter((i) => i.eventType === req.eventType)
+        : items;
+      return of({
+        date: '2026-08-14',
+        eventType: req.eventType ?? null,
+        items: filtered,
+        nextCursor: undefined,
+      } as EventsListResponse);
+    });
+  };
+
+  beforeEach(() => {
+    seq = 0;
+    admin = jasmine.createSpyObj('AdminService', ['listEvents', 'costSummary']);
+    admin.costSummary.and.returnValue(throwError(() => new Error('not under test')));
+    admin.listEvents.and.returnValue(
+      of({ date: '2026-08-14', eventType: null, items: [], nextCursor: undefined }),
+    );
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      declarations: [AdminComponent],
+      providers: [{ provide: AdminService, useValue: admin }],
+      schemas: [],
+    });
+    TestBed.overrideTemplate(AdminComponent, '');
+    component = TestBed.createComponent(AdminComponent).componentInstance;
+  });
+
+  it('groups events into one row per visitor', () => {
+    serve([
+      ev('pageview', '10:00', { visitorId: 'a', path: '/' }),
+      ev('pageview', '10:01', { visitorId: 'a', path: '/apps' }),
+      ev('pageview', '10:02', { visitorId: 'b', path: '/' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors.length).toBe(2);
+    expect(component.visitors.map((v) => v.pageviews).sort()).toEqual([1, 2]);
+  });
+
+  it('keeps an anonymous session that signs in as ONE visitor', () => {
+    // The whole reason visitorId exists. Grouping by userId would split this
+    // person into an anon row and a signed-in row.
+    serve([
+      ev('pageview', '10:00', { visitorId: 'a', path: '/' }),
+      ev('signin', '10:05', { visitorId: 'a', email: 'dom@example.com' }),
+      ev('pageview', '10:06', { visitorId: 'a', email: 'dom@example.com', path: '/profile' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors.length).toBe(1);
+    const v = component.visitors[0];
+    expect(v.identity).toBe('dom@example.com');
+    expect(v.identified).toBe(true);
+    expect(v.converted).toBe(true);
+    expect(v.pageviews).toBe(2);
+  });
+
+  it('labels a visitor who never signs in as anonymous', () => {
+    serve([ev('pageview', '10:00', { visitorId: 'abcdef1234', path: '/' })]);
+    component.loadVisitors();
+
+    expect(component.visitors[0].identified).toBe(false);
+    expect(component.visitors[0].identity).toBe('anon · abcdef12');
+  });
+
+  it('orders the journey forwards even though events arrive newest-first', () => {
+    serve([
+      ev('pageview', '10:02', { visitorId: 'a', path: '/music' }),
+      ev('pageview', '10:00', { visitorId: 'a', path: '/' }),
+      ev('pageview', '10:01', { visitorId: 'a', path: '/apps' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors[0].journey).toEqual(['/', '/apps', '/music']);
+  });
+
+  it('collapses consecutive repeats but keeps a genuine return', () => {
+    serve([
+      ev('pageview', '10:00', { visitorId: 'a', path: '/apps' }),
+      ev('pageview', '10:01', { visitorId: 'a', path: '/apps' }),
+      ev('pageview', '10:02', { visitorId: 'a', path: '/music' }),
+      ev('pageview', '10:03', { visitorId: 'a', path: '/apps' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors[0].journey).toEqual(['/apps', '/music', '/apps']);
+  });
+
+  it('records outbound click-throughs and errors', () => {
+    serve([
+      ev('outbound', '10:01', { visitorId: 'a', app: 'Today In Sports', target: 'https://todayinsports.app' }),
+      ev('error', '10:02', { visitorId: 'a', message: 'boom' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors[0].outbound).toEqual([
+      { app: 'Today In Sports', target: 'https://todayinsports.app' },
+    ]);
+    expect(component.visitors[0].errors).toBe(1);
+  });
+
+  it('sorts most recently active first', () => {
+    serve([
+      ev('pageview', '09:00', { visitorId: 'old', path: '/' }),
+      ev('pageview', '11:00', { visitorId: 'recent', path: '/' }),
+    ]);
+    component.loadVisitors();
+
+    expect(component.visitors[0].visitorId).toBe('recent');
+  });
+
+  it('falls back to userId for rows written before visitorId existed', () => {
+    // The Cognito trigger writes signin rows with no visitorId.
+    serve([ev('signin', '10:00', { email: 'dom@example.com' })]);
+    component.loadVisitors();
+
+    expect(component.visitors.length).toBe(1);
+    expect(component.visitors[0].identity).toBe('dom@example.com');
+  });
+
+  it('walks the cursor to cover the whole day', () => {
+    let call = 0;
+    admin.listEvents.and.callFake(() => {
+      call += 1;
+      return of({
+        date: '2026-08-14',
+        eventType: null,
+        items: [ev('pageview', '10:00', { visitorId: `v${call}`, path: '/' })],
+        nextCursor: call < 3 ? `cursor-${call}` : undefined,
+      } as EventsListResponse);
+    });
+    component.loadVisitors();
+
+    expect(call).toBe(3);
+    expect(component.visitors.length).toBe(3);
+    expect(component.visitorsTruncated).toBe(false);
+  });
+
+  it('flags truncation rather than showing a partial day as complete', () => {
+    admin.listEvents.and.callFake(() =>
+      of({
+        date: '2026-08-14',
+        eventType: null,
+        items: [ev('pageview', '10:00', { visitorId: 'v', path: '/' })],
+        nextCursor: 'always-more',
+      } as EventsListResponse),
+    );
+    component.loadVisitors();
+
+    expect(component.visitorsTruncated).toBe(true);
+  });
+
+  it('surfaces a load failure instead of showing an empty day', () => {
+    admin.listEvents.and.returnValue(throwError(() => ({ status: 500 })));
+    component.loadVisitors();
+
+    expect(component.visitorsError).toBeTruthy();
+    expect(component.visitorsLoading).toBe(false);
+  });
+});

--- a/src/app/components/admin/admin.component.ts
+++ b/src/app/components/admin/admin.component.ts
@@ -14,6 +14,29 @@ interface EventFilter {
   value: AdminEventType | '';
 }
 
+/**
+ * One visitor's day, assembled from their events.
+ *
+ * Grouped by `visitorId` rather than `userId` on purpose: visitorId persists
+ * across sign-in, so someone who browses anonymously and then signs up is one
+ * visitor whose identity resolves partway through, not two separate rows.
+ */
+interface VisitorSession {
+  visitorId: string;
+  /** Email once known, otherwise a short anonymous tag. */
+  identity: string;
+  identified: boolean;
+  /** True when this visitor signed in or signed up during the day. */
+  converted: boolean;
+  firstSeen: string;
+  lastSeen: string;
+  pageviews: number;
+  /** Paths in the order visited, consecutive repeats collapsed. */
+  journey: string[];
+  outbound: { app: string; target: string }[];
+  errors: number;
+}
+
 @Component({
   selector: 'app-admin',
   templateUrl: './admin.component.html',
@@ -36,6 +59,12 @@ export class AdminComponent implements OnInit {
     { label: 'Sign-ins', value: 'signin' },
     { label: 'Sign-ups', value: 'signup' },
   ];
+
+  visitors: VisitorSession[] = [];
+  visitorsLoading = false;
+  visitorsError = '';
+  visitorsTruncated = false;
+  expandedVisitor: string | null = null;
 
   errors: AdminEvent[] = [];
   errorsCursor: string | undefined;
@@ -67,6 +96,7 @@ export class AdminComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadEvents();
+    this.loadVisitors();
     this.loadErrors();
     this.loadCost();
   }
@@ -130,6 +160,127 @@ export class AdminComponent implements OnInit {
       });
   }
 
+  /**
+   * Visitors needs the whole day, not the first page, so it walks the cursor.
+   * Bounded: at PAGE_LIMIT × MAX_PAGES the total stops growing and the card
+   * says so rather than quietly showing a partial day as if it were complete.
+   */
+  loadVisitors(): void {
+    const date = (this.dateForm.value.date as string) || this.todayIso();
+    this.visitorsLoading = true;
+    this.visitorsError = '';
+    this.visitors = [];
+    this.visitorsTruncated = false;
+    this.expandedVisitor = null;
+
+    const PAGE_LIMIT = 200;
+    const MAX_PAGES = 15;
+    const collected: AdminEvent[] = [];
+
+    const fetchPage = (cursor?: string, page = 1): void => {
+      this.admin.listEvents({ date, limit: PAGE_LIMIT, cursor }).subscribe({
+        next: (res: EventsListResponse) => {
+          collected.push(...res.items);
+          if (res.nextCursor && page < MAX_PAGES) {
+            fetchPage(res.nextCursor, page + 1);
+            return;
+          }
+          this.visitorsTruncated = !!res.nextCursor;
+          this.visitors = this.buildVisitors(collected);
+          this.visitorsLoading = false;
+        },
+        error: (err) => {
+          this.visitorsError = this.errorMessage(err, 'Failed to load visitors');
+          this.visitorsLoading = false;
+        },
+      });
+    };
+
+    fetchPage();
+  }
+
+  /** Fold a day of raw events into one row per visitor. */
+  private buildVisitors(events: AdminEvent[]): VisitorSession[] {
+    // Events arrive newest-first; the journey only reads correctly forwards.
+    const chronological = [...events].sort((a, b) =>
+      a.eventTime.localeCompare(b.eventTime),
+    );
+
+    const byVisitor = new Map<string, VisitorSession>();
+
+    for (const ev of chronological) {
+      // Pre-Visitors rows and the Cognito trigger's own rows have no
+      // visitorId; fall back to userId so they still appear.
+      const key = ev.visitorId || ev.userId;
+      if (!key) continue;
+
+      let v = byVisitor.get(key);
+      if (!v) {
+        v = {
+          visitorId: key,
+          identity: `anon · ${key.slice(0, 8)}`,
+          identified: false,
+          converted: false,
+          firstSeen: ev.eventTime,
+          lastSeen: ev.eventTime,
+          pageviews: 0,
+          journey: [],
+          outbound: [],
+          errors: 0,
+        };
+        byVisitor.set(key, v);
+      }
+
+      v.lastSeen = ev.eventTime;
+
+      // Identity can arrive on any event in the day — the sign-in row, or any
+      // row written after it. Once known it sticks.
+      if (!v.identified && ev.email) {
+        v.identity = ev.email;
+        v.identified = true;
+      }
+
+      switch (ev.eventType) {
+        case 'pageview':
+          v.pageviews += 1;
+          if (ev.path && v.journey[v.journey.length - 1] !== ev.path) {
+            v.journey.push(ev.path);
+          }
+          break;
+        case 'outbound':
+          v.outbound.push({ app: ev.app || '—', target: ev.target || '' });
+          break;
+        case 'error':
+          v.errors += 1;
+          break;
+        case 'signin':
+        case 'signup':
+          v.converted = true;
+          break;
+      }
+    }
+
+    // Most recently active first — that is the useful default when checking
+    // who is on the site right now.
+    return [...byVisitor.values()].sort((a, b) => b.lastSeen.localeCompare(a.lastSeen));
+  }
+
+  toggleVisitor(visitorId: string): void {
+    this.expandedVisitor = this.expandedVisitor === visitorId ? null : visitorId;
+  }
+
+  get identifiedCount(): number {
+    return this.visitors.filter((v) => v.identified).length;
+  }
+
+  formatSpan(v: VisitorSession): string {
+    const mins = Math.round(
+      (new Date(v.lastSeen).getTime() - new Date(v.firstSeen).getTime()) / 60000,
+    );
+    if (mins < 1) return '< 1 min';
+    return `${mins} min`;
+  }
+
   /** Errors get their own card — they are the one type you act on. */
   loadErrors(): void {
     const date = this.dateForm.value.date as string | null;
@@ -180,9 +331,10 @@ export class AdminComponent implements OnInit {
     this.expandedError = this.expandedError === eventId ? null : eventId;
   }
 
-  /** Both cards read the same date, so one submit reloads both. */
+  /** Every card reads the same date, so one submit reloads them all. */
   reload(): void {
     this.loadEvents();
+    this.loadVisitors();
     this.loadErrors();
   }
 


### PR DESCRIPTION
Follow-on to #178. Makes the activity data legible — the point was to see who is coming, and raw event rows do not answer that.

## Visitors card

One row per visitor for the selected day: identity, pageviews, click-throughs, errors, and how long they were around. Expanding a row shows the journey as an ordered path and which apps they left for.

Grouped by `visitorId`, **not** `userId`. That is the whole reason `visitorId` persists across sign-in: someone who browses anonymously and then signs up is one visitor whose identity resolves partway through, rather than an anonymous row and a separate signed-in row that you would never connect. There is a test that fails if the grouping key changes.

Anonymous visitors render muted and identified ones at full contrast, since a known email is what you actually scan for. A visitor who signed in or up during the day gets a `converted` pill.

The card walks the pagination cursor to cover the whole day and says so when it hits the 3,000-event cap, rather than showing a partial day as if it were complete.

## Also fixes the test setup

The `test` target in `angular.json` had no `stylePreprocessorOptions`, so any component spec importing `styles/variables` — which every component does — failed to build under karma. That is why the suite only ever contained one trivial spec. Now matches `build`, which unblocks component testing generally.

## Verification

- 27 tests pass (11 new, covering grouping, stitching, journey order, repeat collapsing, cursor walking, truncation, error state)
- Mutation-checked: switching the grouping key to `userId` fails the stitching test
- `npm run build:prod` clean; viewed against stubbed data before shipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69