### PR TITLE
Honour Global Privacy Control, and say what we actually collect

### DIFF
--- a/src/app/components/privacy/privacy.component.html
+++ b/src/app/components/privacy/privacy.component.html
@@ -26,6 +26,13 @@
         can see usage. Rows expire automatically after 90 days.
       </li>
       <li>
+        <strong>Pages you visit on xomware.com</strong> &mdash; the path (e.g. <code>/apps</code>), the time, which
+        app link you clicked through to, your browser's user-agent string, and any error the site hits while you
+        are using it. This is stored on Xomware's own servers, expires after 90 days, and is used only to see
+        which apps people are interested in and to find bugs. You do not need an account for this to be recorded
+        &mdash; see <a href="#tracking">Cookies and tracking</a> below, including how to turn it off.
+      </li>
+      <li>
         <strong>App-specific content you create</strong> &mdash; e.g. recipes you save in Xom App&eacute;tit, files
         you edit, or any other data you enter into a Xomware app.
       </li>
@@ -45,17 +52,34 @@
       authenticate you &mdash; we receive your email + display name + avatar URL and nothing else).
     </p>
 
-    <h2>Cookies and tracking</h2>
+    <h2 id="tracking">Cookies and tracking</h2>
     <p>
       Xomware uses session tokens issued by Cognito to keep you signed in. There is no third-party advertising,
-      no cross-site tracking, and no analytics that send your data outside Xomware.
+      no cross-site tracking, and no analytics product &mdash; no Google Analytics, no ad pixels, nothing that
+      sends your browsing to anyone else. The activity described above goes to Xomware's own servers and stays
+      there.
+    </p>
+    <p>
+      To count visitors without accounts, the site stores a random identifier in your browser's local storage.
+      It is a random string, it is not linked to anything about you, and it is only readable by
+      <code>xomware.com</code>. If you later sign in, that identifier is associated with your account so the
+      operator can see the visit that led to a sign-up as one session rather than two.
+    </p>
+    <p>
+      <strong>How to turn it off.</strong> If your browser sends
+      <a href="https://globalprivacycontrol.org/" rel="noopener">Global Privacy Control</a> or
+      &ldquo;Do Not Track&rdquo;, Xomware records nothing at all &mdash; no identifier is created and no request
+      is sent. Most privacy-focused browsers and extensions send one of these by default, and both are a setting
+      in your browser. Clearing your site data also removes the identifier.
     </p>
 
     <h2>Your rights</h2>
     <p>
       You can delete your account at any time from the profile page, which removes your row from the
       identity pool and your profile data from DynamoDB. App-specific content (recipes, etc.) is
-      removed as part of account deletion. To request a copy of your data or ask any other question, email
+      removed as part of account deletion. Activity rows are not deleted immediately &mdash; they expire on
+      their own within 90 days &mdash; but you can email to have them removed sooner.
+      To request a copy of your data or ask any other question, email
       <a href="mailto:dominickj.giordano&#64;gmail.com">dominickj.giordano&#64;gmail.com</a>.
     </p>
 

--- a/src/app/components/privacy/privacy.component.ts
+++ b/src/app/components/privacy/privacy.component.ts
@@ -6,5 +6,7 @@ import { Component } from '@angular/core';
   styleUrls: ['./privacy.component.scss'],
 })
 export class PrivacyComponent {
-  readonly lastUpdated = 'May 4, 2026';
+  // The policy's own "Changes" section promises this moves whenever the policy
+  // does. Bumped for the activity-logging disclosure.
+  readonly lastUpdated = 'August 14, 2026';
 }

--- a/src/app/services/activity.service.spec.ts
+++ b/src/app/services/activity.service.spec.ts
@@ -191,6 +191,67 @@ describe('ActivityService', () => {
     });
   });
 
+  describe('privacy signals', () => {
+    const withSignal = (prop: string, value: unknown) => {
+      Object.defineProperty(navigator, prop, { value, configurable: true });
+    };
+    afterEach(() => {
+      for (const prop of ['globalPrivacyControl', 'doNotTrack']) {
+        if (prop in navigator) {
+          Object.defineProperty(navigator, prop, { value: undefined, configurable: true });
+        }
+      }
+    });
+
+    it('sends nothing at all when Global Privacy Control is set', async () => {
+      withSignal('globalPrivacyControl', true);
+      resolveAuth(false);
+      service.trackPageview('/');
+      service.trackOutbound('Xomify', 'https://xomify.xomware.com');
+      service.trackError('boom');
+      await flush();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('sends nothing when Do Not Track is set', async () => {
+      withSignal('doNotTrack', '1');
+      resolveAuth(false);
+      service.trackPageview('/');
+      await flush();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('never creates a visitor id for a visitor who refused', async () => {
+      withSignal('globalPrivacyControl', true);
+      resolveAuth(false);
+      service.trackPageview('/');
+      await flush();
+
+      expect(localStorage.getItem('xw_visitor_id')).toBeNull();
+    });
+
+    it('discards events buffered before the refusal was noticed', async () => {
+      // Buffered while auth was unresolved, then GPC turns up. The refusal
+      // applies to those too, not only to what comes after.
+      service.trackPageview('/');
+      withSignal('globalPrivacyControl', true);
+      resolveAuth(false);
+      await flush();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('still tracks when no privacy signal is present', async () => {
+      resolveAuth(false);
+      service.trackPageview('/');
+      await flush();
+
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+
   it('swallows transport failures rather than surfacing them', async () => {
     fetchSpy.and.returnValue(Promise.reject(new Error('offline')));
     resolveAuth(false);

--- a/src/app/services/activity.service.ts
+++ b/src/app/services/activity.service.ts
@@ -143,7 +143,40 @@ export class ActivityService {
     ]);
   }
 
+  /**
+   * Global Privacy Control and Do Not Track. A visitor who sets either has
+   * asked, in the only machine-readable way available to them, not to be
+   * tracked — so they are not, at all: no request, no visitor id, no row.
+   *
+   * This is what lets the site do first-party analytics without a consent
+   * banner in good conscience. Checked per-send rather than cached because a
+   * browser extension can flip it mid-session.
+   */
+  private get trackingRefused(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const nav = navigator as Navigator & {
+      globalPrivacyControl?: boolean;
+      doNotTrack?: string | null;
+      msDoNotTrack?: string | null;
+    };
+    if (nav.globalPrivacyControl === true) return true;
+    const dnt =
+      nav.doNotTrack ??
+      nav.msDoNotTrack ??
+      (typeof window !== 'undefined'
+        ? (window as Window & { doNotTrack?: string | null }).doNotTrack
+        : null);
+    return dnt === '1' || dnt === 'yes';
+  }
+
   private async send(events: ActivityEvent[]): Promise<void> {
+    if (this.trackingRefused) {
+      // Drop anything buffered too — the refusal applies retroactively within
+      // the session, not just to events raised after it was noticed.
+      this.pending = [];
+      return;
+    }
+
     if (!this.authResolved) {
       if (this.pending.length < ActivityService.MAX_PENDING) {
         this.pending.push(...events);


### PR DESCRIPTION
Corrects a problem the activity logging created, and closes the consent question properly.

## The privacy policy became misleading when tracking shipped

It said Xomware "uses session tokens issued by Cognito to keep you signed in" with "no cross-site tracking, and no analytics that send your data outside Xomware".

Every clause was still literally true. But as of today the site records every page visit, click-through and error against a persistent identifier, and the page said nothing about it — a reader would conclude only session tokens were involved. Misleading by omission is still misleading, and an inaccurate privacy policy is a more concrete exposure than the consent question itself.

Now states plainly what is collected, that it happens without an account, that it lives on Xomware's own servers, and that it expires in 90 days.

## Gives visitors a real way out, without a consent banner

A browser sending **Global Privacy Control** or **Do Not Track** is now not recorded at all — no identifier is created, no request is sent, and anything already buffered is discarded. Checked per-send, since an extension can flip it mid-session.

A consent banner is the stricter option, but it would wreck the landing page you just built for disproportionate benefit at this traffic level. GPC is the machine-readable signal regulators actually point to, costs no UI, and makes "we respect your choice" true rather than decorative. If real EU traffic ever shows up, a banner is the upgrade path.

## Verification

- 32 tests pass (5 new on the privacy signals)
- Mutation-checked: removing the opt-out check fails 4 tests, including that no identifier is written to localStorage for a visitor who refused
- `lastUpdated` bumped, as the policy's own Changes section promises

## One thing left for you

That same Changes section also promises **"material changes will also be announced on the home page"**. Adding activity logging is a material change, and I have not built that announcement — it is a visible design decision on the landing page rather than something to slip in unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69